### PR TITLE
Add author attribution + Add AI discoverability for LLMs

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,98 @@
+# Jetson AI Lab
+
+> Jetson AI Lab is NVIDIA's open-source resource for deploying generative AI on NVIDIA Jetson edge devices (Orin Nano, AGX Orin, Thor). It provides tutorials, model deployment guides, and benchmarks for running LLMs, VLMs, and VLA models locally on Jetson hardware.
+
+Jetson AI Lab covers the full workflow: initial device setup, inference engine installation (vLLM, Ollama, llama.cpp, TensorRT), model deployment, fine-tuning, and benchmarking. All content targets on-device edge AI — no cloud required.
+
+- Source code: https://github.com/NVIDIA-AI-IOT/jetson-ai-lab
+- Full documentation: https://www.jetson-ai-lab.com/llms-full.txt
+
+## Getting Started
+
+- [Initial Setup Guide for Jetson Orin Nano](https://www.jetson-ai-lab.com/tutorials/initial-setup-jetson-orin-nano/): Complete setup guide covering firmware updates, JetPack 6.2 flashing via microSD card, and enabling MAXN SUPER performance mode
+- [Initial Setup using SDK Manager](https://www.jetson-ai-lab.com/tutorials/initial-setup-sdk-manager/): Alternative setup method using NVIDIA SDK Manager to flash firmware and JetPack, including NVMe SSD support
+- [SSD + Docker Setup](https://www.jetson-ai-lab.com/tutorials/ssd-docker-setup/): Set up NVMe SSD storage and configure Docker on Jetson for optimal performance with AI containers
+- [RAM Optimization](https://www.jetson-ai-lab.com/tutorials/ram-optimization/): Optimize system RAM by disabling desktop GUI, unnecessary services, and mounting swap for large model workloads
+
+## Inference Engines & Fundamentals
+
+- [Introduction to GenAI on Jetson](https://www.jetson-ai-lab.com/tutorials/genai-on-jetson-llms-vlms/): Practical intro to running LLMs and VLMs on Jetson using Ollama for experimentation and vLLM for production performance
+- [Ollama on Jetson](https://www.jetson-ai-lab.com/tutorials/ollama/): Install and run Ollama for easy local LLM deployment, covering native installation, Docker containers, and Open WebUI
+- [GenAI Benchmarking](https://www.jetson-ai-lab.com/tutorials/genai-benchmarking/): Benchmark LLMs and VLMs on Jetson using vLLM — measure throughput, latency, TTFT, and key performance metrics
+
+## Model Optimization
+
+- [Fine-tune LLMs on Jetson](https://www.jetson-ai-lab.com/tutorials/finetune-on-jetson/): Fine-tune large language models directly on Jetson using PyTorch and Hugging Face TRL — Full SFT (4B), LoRA (9B), and QLoRA (27B)
+- [TensorRT Edge-LLM on Jetson](https://www.jetson-ai-lab.com/tutorials/tensorrt-edge-llm/): Use NVIDIA TensorRT Edge-LLM for quantization, ONNX export, engine builds, and pure C++ on-device inference
+
+## Applications
+
+- [Live VLM WebUI](https://www.jetson-ai-lab.com/tutorials/live-vlm-webui/): Real-time Vision Language Model interface with WebRTC webcam streaming, OpenAI-compatible API, and interactive prompt editor
+- [OpenClaw on Jetson](https://www.jetson-ai-lab.com/tutorials/openclaw/): Fully local AI personal assistant on Jetson with OpenClaw and WhatsApp, no cloud APIs needed
+- [Jetson Platform Services](https://www.jetson-ai-lab.com/tutorials/jetson-platform-services/): Build AI-powered edge applications using modular microservices for video analytics, VLM alerts, and zero-shot detection
+- [NanoOWL](https://www.jetson-ai-lab.com/tutorials/nanoowl/): OWL-ViT optimized for real-time open-vocabulary object detection on Jetson with TensorRT
+
+## Vision Language Models (VLMs)
+
+- [Gemma 4 on Jetson](https://www.jetson-ai-lab.com/tutorials/gemma4-on-jetson/): Run Google Gemma 4 models (E2B, E4B, 26B-A4B, 31B) on Jetson with vLLM or llama.cpp — reasoning, tool calling, and audio
+- [Cosmos Reason2 on Jetson](https://www.jetson-ai-lab.com/tutorials/cosmos-reason2-vlm/): Run NVIDIA Cosmos Reason2 (2B/8B) with vLLM and Live VLM WebUI for real-time vision inference
+
+## Vision-Language-Action (VLA) Models
+
+- [OpenPi on Jetson Thor](https://www.jetson-ai-lab.com/tutorials/openpi_on_thor/): Deploy Physical Intelligence's OpenPi VLA model on Jetson Thor with TensorRT NVFP4 quantization for low-latency robotics inference
+
+## Workshops
+
+- [GTC 2026 Workshop](https://www.jetson-ai-lab.com/tutorials/gtc26/): 100-minute hands-on workshop — deploy AI microservices, run VLMs, and build conversational AI pipelines on Jetson Thor
+- [GTC DC 2025 Workshop](https://www.jetson-ai-lab.com/tutorials/workshop-gtc-dc-2025/): Inference optimization on Jetson Thor with vLLM — production-grade LLM serving, quantization (FP16/FP8/FP4), speculative decoding
+- [Hackathon Guide](https://www.jetson-ai-lab.com/tutorials/hackathon-guide/): Setup tips, project ideas, and resources for building AI projects on Jetson at hackathons
+
+## Supported Models
+
+The full model catalog with deployment commands is at https://www.jetson-ai-lab.com/models/
+
+### NVIDIA Models
+- [Nemotron3 Nano 4B](https://www.jetson-ai-lab.com/models/nemotron3-nano-4b/): Compact 4B model with llama.cpp support on Jetson Orin and Thor
+- [Nemotron3 Nano 30B-A3B](https://www.jetson-ai-lab.com/models/nemotron-3-nano-30b-a3b/): Hybrid MoE reasoning model, 30B total / 3.5B active parameters
+- [Nemotron Nano 9B v2](https://www.jetson-ai-lab.com/models/nemotron-nano-9b-v2/): 9B hybrid architecture with Mamba-2 and attention layers
+- [Nemotron Nano 12B VL](https://www.jetson-ai-lab.com/models/nemotron-nano-12b-vl/): Vision-language model for image understanding and multimodal reasoning
+- [Cosmos Reason 1 7B](https://www.jetson-ai-lab.com/models/cosmos-reason1-7b/): 7B reasoning VLM for physical AI and robotics
+- [Cosmos Reason 2 2B](https://www.jetson-ai-lab.com/models/cosmos-reason2-2b/): Compact 2B VLM with chain-of-thought reasoning for edge deployment
+- [Cosmos Reason 2 8B](https://www.jetson-ai-lab.com/models/cosmos-reason2-8b/): 8B VLM with advanced chain-of-thought reasoning
+
+### Google Gemma Models
+- [Gemma 3 1B](https://www.jetson-ai-lab.com/models/gemma3-1b/): Efficient 1B parameter model
+- [Gemma 3 4B](https://www.jetson-ai-lab.com/models/gemma3-4b/): Versatile 4B default Gemma 3 variant
+- [Gemma 3 12B](https://www.jetson-ai-lab.com/models/gemma3-12b/): 12B model for advanced reasoning
+- [Gemma 3 27B](https://www.jetson-ai-lab.com/models/gemma3-27b/): Flagship 27B Gemma model
+- [Gemma 4 E2B](https://www.jetson-ai-lab.com/models/gemma4-e2b/): Compact frontier Gemma 4 for multimodal and agentic workloads
+- [Gemma 4 E4B](https://www.jetson-ai-lab.com/models/gemma4-e4b/): Gemma 4 E4B with Q4_K_M GGUF support via llama.cpp
+- [Gemma 4 26B-A4B](https://www.jetson-ai-lab.com/models/gemma4-26b-a4b/): 26B MoE frontier model for reasoning and multimodal workflows
+- [Gemma 4 31B](https://www.jetson-ai-lab.com/models/gemma4-31b/): Gemma 4 31B with Q4_K_M GGUF support via llama.cpp
+
+### Meta Llama Models
+- [Llama 3.1 8B](https://www.jetson-ai-lab.com/models/llama3-1-8b/): 8B instruction-tuned model optimized for Jetson
+- [Llama 3.1 70B](https://www.jetson-ai-lab.com/models/llama3-1-70b/): 70B flagship model for Jetson Thor
+- [Llama 3.2 3B](https://www.jetson-ai-lab.com/models/llama3-2-3b/): Compact 3B model for resource-constrained deployments
+
+### Alibaba Qwen Models
+- [Qwen3 4B](https://www.jetson-ai-lab.com/models/qwen3-4b/): Efficient 4B instruction-tuned model
+- [Qwen3 8B](https://www.jetson-ai-lab.com/models/qwen3-8b/): 8B instruction-tuned model
+- [Qwen3 32B](https://www.jetson-ai-lab.com/models/qwen3-32b/): 32B flagship for advanced reasoning
+- [Qwen3 30B-A3B](https://www.jetson-ai-lab.com/models/qwen3-30b-a3b/): MoE model, 30B total / 3B active
+- [Qwen3 VL 4B](https://www.jetson-ai-lab.com/models/qwen3-vl-4b/): 4B vision-language model
+- [Qwen3 VL 8B](https://www.jetson-ai-lab.com/models/qwen3-vl-8b/): 8B vision-language model
+
+### OpenAI Models
+- [GPT OSS 20B](https://www.jetson-ai-lab.com/models/gpt-oss-20b/): Open-source 20B language model
+- [GPT OSS 120B](https://www.jetson-ai-lab.com/models/gpt-oss-120b/): Open-source 120B language model for Jetson Thor
+
+### Mistral Models
+- [Ministral 3 3B Instruct](https://www.jetson-ai-lab.com/models/ministral3-3b-instruct/): Compact 3B instruction-tuned model
+- [Ministral 3 8B Instruct](https://www.jetson-ai-lab.com/models/ministral3-8b-instruct/): Versatile 8B instruction-tuned model
+
+## Other Pages
+
+- [Model Catalog](https://www.jetson-ai-lab.com/models/): Browse all supported models with one-click deployment commands for Jetson Orin and Thor
+- [Community Projects](https://www.jetson-ai-lab.com/community/): Community-contributed projects, demos, and integrations built on Jetson
+- [Research](https://www.jetson-ai-lab.com/research/): Academic research and papers related to Jetson edge AI

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -24,6 +24,14 @@ const tutorials = defineCollection({
 		featured: z.boolean().optional(),
 		isNew: z.boolean().optional(), // Mark as new tutorial
 		hero_image: z.string().optional(), // Optional background image for hero section
+		authors: z
+			.array(
+				z.object({
+					name: z.string(),
+					github: z.string().optional(),
+				})
+			)
+			.optional(),
 	}),
 });
 

--- a/src/content/tutorials/applications/jetson-platform-services.md
+++ b/src/content/tutorials/applications/jetson-platform-services.md
@@ -5,6 +5,8 @@ category: "Applications"
 section: "AI Microservices"
 order: 2
 tags: ["jps", "jetson", "microservices", "vlm", "deepstream", "video-analytics", "edge-ai", "nanoowl"]
+authors:
+  - name: "sochoa"
 ---
 
 Jetson Platform Services (JPS) provide a platform to simplify development, deployment and management of Edge AI applications on NVIDIA Jetson. JPS is a modular & extensible architecture for developers to distill large complex applications into smaller modular microservices with APIs to integrate into other apps & services.

--- a/src/content/tutorials/applications/live-vlm-webui.md
+++ b/src/content/tutorials/applications/live-vlm-webui.md
@@ -7,6 +7,9 @@ order: 1
 tags: ["vlm", "vision", "camera", "live-streaming", "webrtc", "ollama", "gemma", "qwen", "llama-vision", "multimodal"]
 featured: true
 isNew: true
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 ![Live VLM WebUI](https://github.com/NVIDIA-AI-IOT/live-vlm-webui/raw/main/docs/images/chrome_app-running_light-theme.jpg)

--- a/src/content/tutorials/applications/nanoowl.md
+++ b/src/content/tutorials/applications/nanoowl.md
@@ -5,6 +5,9 @@ category: "Applications"
 section: "Vision Transformers"
 order: 1
 tags: ["nanoowl", "owl-vit", "vision", "tensorrt", "object-detection", "jetson", "real-time"]
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 Let's run [NanoOWL](https://github.com/NVIDIA-AI-IOT/nanoowl), [OWL-ViT](https://huggingface.co/docs/transformers/model_doc/owlvit) optimized to run real-time on Jetson with [NVIDIA TensorRT](https://developer.nvidia.com/tensorrt).

--- a/src/content/tutorials/applications/openclaw.md
+++ b/src/content/tutorials/applications/openclaw.md
@@ -7,6 +7,11 @@ order: 2
 tags: ["openclaw", "ollama", "vllm", "qwen3.5", "nemotron", "jetson-orin-nano", "jetson-orin", "jetson-thor", "agent", "local-llm", "tool-calling", "whatsapp"]
 isNew: true
 hideMigrationNotice: true
+authors:
+  - name: "Khalil BenKhaled"
+    github: "NebulaTurnip27"
+  - name: "Asier Arranz"
+    github: "asierarranz"
 ---
 
 OpenClaw also works on Jetson devices. You can run it on a **Jetson AGX Orin** or **AGX Thor**, but even if you have a **Jetson Orin Nano (8GB)**, you can still run it locally with the right setup.

--- a/src/content/tutorials/fundamentals/gemma4-on-jetson.mdx
+++ b/src/content/tutorials/fundamentals/gemma4-on-jetson.mdx
@@ -7,6 +7,9 @@ tags: ["gemma4", "gemma", "jetson", "llm", "vllm", "llama.cpp", "orin", "thor", 
 model: "Gemma 4"
 featured: true
 isNew: true
+authors:
+  - name: "Khalil BenKhaled"
+    github: "NebulaTurnip27"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/fundamentals/genai-benchmarking.md
+++ b/src/content/tutorials/fundamentals/genai-benchmarking.md
@@ -7,6 +7,9 @@ order: 2
 tags: ["benchmarking", "vllm", "llm", "vlm", "performance", "throughput", "latency", "ttft", "jetson"]
 featured: false
 isNew: true
+authors:
+  - name: "Khalil BenKhaled"
+    github: "NebulaTurnip27"
 ---
 
 In this tutorial, we will walk you through benchmarking Large Language Models (LLMs) and Vision Language Models (VLMs) on your Jetson. For this guide, we'll use vLLM as our inference engine of choice due to its high throughput and efficiency. We'll focus on measuring the model's speed and performance, which are critical to give you an idea of how your system will react under different loads.

--- a/src/content/tutorials/fundamentals/genai-on-jetson-llms-vlms.md
+++ b/src/content/tutorials/fundamentals/genai-on-jetson-llms-vlms.md
@@ -7,6 +7,9 @@ order: 1
 tags: ["fundamentals", "genai", "jetson", "llm", "vlm", "ollama", "vllm", "speculative-decoding", "eagle3"]
 model: "ollama / vllm"
 featured: true
+authors:
+  - name: "Khalil BenKhaled"
+    github: "NebulaTurnip27"
 ---
 
 Running Generative AI on Jetson usually comes down to two workflows:

--- a/src/content/tutorials/fundamentals/ollama.md
+++ b/src/content/tutorials/fundamentals/ollama.md
@@ -5,6 +5,9 @@ category: "Fundamentals"
 section: "Inference Engines"
 order: 3
 tags: ["ollama", "llm", "jetson", "docker", "open-webui", "inference", "text-generation"]
+authors:
+  - name: "Dustin Franklin"
+    github: "dusty-nv"
 ---
 
 [Ollama](https://ollama.com) is a popular open-source tool that allows users to easily run large language models (LLMs) locally on their own computer, serving as an accessible entry point to LLMs for many.

--- a/src/content/tutorials/model-optimization/finetune-on-jetson.mdx
+++ b/src/content/tutorials/model-optimization/finetune-on-jetson.mdx
@@ -7,6 +7,9 @@ order: 1
 tags: ["fine-tuning", "LoRA", "QLoRA", "SFT", "Qwen", "PyTorch", "TRL", "Jetson Thor", "training"]
 featured: false
 isNew: true
+authors:
+  - name: "Aditya Sahu"
+    github: "adsahu-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/model-optimization/tensorrt-edge-llm.mdx
+++ b/src/content/tutorials/model-optimization/tensorrt-edge-llm.mdx
@@ -7,6 +7,9 @@ order: 1
 tags: ["edge-llm", "tensorrt", "cosmos-reason2", "qwen3", "int4", "nvfp4", "quantization", "jetson-thor", "jetson-orin-nano", "vlm", "llm", "memory-optimization", "onnx", "c++"]
 featured: false
 isNew: true
+authors:
+  - name: "Aditya Sahu"
+    github: "adsahu-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/setup/initial-setup-jetson-orin-nano.mdx
+++ b/src/content/tutorials/setup/initial-setup-jetson-orin-nano.mdx
@@ -6,6 +6,9 @@ section: "Jetson Setup"
 order: 1
 tags: ["setup", "jetson", "orin-nano", "jetpack", "firmware", "microsd", "getting-started"]
 hero_image: "/images/hero/isometric_jon-devkit.png"
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/setup/initial-setup-sdk-manager.mdx
+++ b/src/content/tutorials/setup/initial-setup-sdk-manager.mdx
@@ -5,6 +5,9 @@ category: "Setup"
 section: "Jetson Setup"
 order: 2
 tags: ["setup", "jetson", "orin-nano", "jetpack", "sdk-manager", "nvme", "ssd", "getting-started"]
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/setup/ram-optimization.md
+++ b/src/content/tutorials/setup/ram-optimization.md
@@ -5,6 +5,9 @@ category: "Setup"
 section: "Environment Setup"
 order: 4
 tags: ["setup", "ram", "memory", "optimization", "swap", "jetson-orin-nano", "jetson"]
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 Running large language models requires significant RAM. On devices like the **Jetson Orin Nano** with only 8 GB of RAM, it is crucial to free as much memory as possible for model inference.

--- a/src/content/tutorials/setup/ssd-docker-setup.mdx
+++ b/src/content/tutorials/setup/ssd-docker-setup.mdx
@@ -5,6 +5,9 @@ category: "Setup"
 section: "Environment Setup"
 order: 3
 tags: ["setup", "jetson", "ssd", "nvme", "docker", "storage", "containers"]
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/vla/openpi_on_thor.md
+++ b/src/content/tutorials/vla/openpi_on_thor.md
@@ -6,6 +6,9 @@ section: "Vision-Language-Action Models"
 order: 1
 tags: ["vla", "openpi", "pi0.5", "robotics", "jetson-thor", "tensorrt", "nvfp4", "fp8", "inference", "vision-language-action"]
 isNew: true
+authors:
+  - name: "Aditya Sahu"
+    github: "adsahu-nv"
 ---
 
 Deploy [Physical Intelligence's](https://www.physicalintelligence.company/) OpenPi **π₀.₅ Vision-Language-Action (VLA)** model on **NVIDIA Jetson AGX Thor** with TensorRT NVFP4 quantization for low-latency end-to-end inference.

--- a/src/content/tutorials/vlm/cosmos-reason2-vlm.md
+++ b/src/content/tutorials/vlm/cosmos-reason2-vlm.md
@@ -7,6 +7,9 @@ order: 2
 tags: ["vlm", "vision", "cosmos", "cosmos-reason2", "vllm", "fp8", "jetson-orin", "jetson-thor", "ngc", "live-vlm-webui", "multimodal", "reasoning", "2b", "8b"]
 model: "vllm"
 isNew: true
+authors:
+  - name: "Johnny Nuñez"
+    github: "johnnynunez"
 ---
 
 ![Cosmos Reason2 on Jetson](/images/tutorials/cosmos-reason2-8b.jpg)

--- a/src/content/tutorials/workshops/gtc26.mdx
+++ b/src/content/tutorials/workshops/gtc26.mdx
@@ -7,6 +7,13 @@ order: 0
 tags: ["Jetson Thor", "LLM", "VLM", "Ollama", "vLLM", "Physical AI", "GTC", "Workshop"]
 featured: true
 isNew: true
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
+  - name: "Aditya Sahu"
+    github: "adsahu-nv"
+  - name: "Khalil BenKhaled"
+    github: "NebulaTurnip27"
 ---
 
 # GTC 2026 Workshop

--- a/src/content/tutorials/workshops/hackathon-guide.mdx
+++ b/src/content/tutorials/workshops/hackathon-guide.mdx
@@ -6,6 +6,9 @@ section: "Hands-on Labs"
 order: 2
 tags: ["Hackathon", "Setup", "Jetson Orin Nano", "Jetson AGX Orin", "Jetson Thor", "Getting Started"]
 featured: false
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 import Tabs from '../../../components/Tabs.astro';

--- a/src/content/tutorials/workshops/workshop-gtc-dc-2025.md
+++ b/src/content/tutorials/workshops/workshop-gtc-dc-2025.md
@@ -6,6 +6,9 @@ section: "Hands-on Labs"
 order: 1
 tags: ["Jetson Thor", "vLLM", "Quantization", "FP8", "FP4", "Speculative Decoding", "LLM Serving", "GTC"]
 featured: false
+authors:
+  - name: "Chitoku YATO"
+    github: "tokk-nv"
 ---
 
 # From AI Exploration to Production Deployment

--- a/src/layouts/TutorialLayout.astro
+++ b/src/layouts/TutorialLayout.astro
@@ -29,6 +29,10 @@ if (!tutorial) {
 const rendered = tutorial ? await tutorial.render() : null;
 const Content = rendered?.Content;
 const headings = rendered?.headings ?? [];
+
+const githubRepo = 'https://github.com/NVIDIA-AI-IOT/jetson-ai-lab';
+const sourceUrl = tutorial ? `${githubRepo}/blob/main/src/content/tutorials/${tutorial.id}` : '#';
+const issuesUrl = `${githubRepo}/issues`;
 ---
 
 <Layout title={tutorial?.data.title ?? 'Tutorial Not Found'} description={tutorial?.data.description ?? 'The requested tutorial could not be found.'}>
@@ -88,6 +92,38 @@ const headings = rendered?.headings ?? [];
 					<p class="text-xl text-slate-300 mb-8 leading-relaxed max-w-2xl">
 						{tutorial.data.description}
 					</p>
+
+					{tutorial.data.authors && tutorial.data.authors.length > 0 && (
+						<div class="flex flex-wrap items-center gap-3 mt-2">
+							<span class="text-xs font-semibold uppercase tracking-wider text-slate-500 mr-1 leading-none self-center">
+								{tutorial.data.authors.length > 1 ? 'Authors' : 'Author'}
+							</span>
+							{tutorial.data.authors.map((author) => {
+								const inner = (
+									<span class="inline-flex items-center gap-2 rounded-full bg-white/10 pl-1 pr-3 py-1 text-sm text-slate-300 backdrop-blur-sm border border-white/10 hover:bg-white/15 hover:border-white/20 transition-all">
+										{author.github ? (
+											<img
+												src={`https://github.com/${author.github}.png?size=64`}
+												alt={author.name}
+												class="w-6 h-6 rounded-full"
+												loading="lazy"
+											/>
+										) : (
+											<span class="w-6 h-6 rounded-full bg-slate-600 flex items-center justify-center text-xs font-medium text-slate-300">
+												{author.name.charAt(0)}
+											</span>
+										)}
+										{author.name}
+									</span>
+								);
+								return author.github ? (
+									<a href={`https://github.com/${author.github}`} target="_blank" rel="noopener noreferrer">
+										{inner}
+									</a>
+								) : inner;
+							})}
+						</div>
+					)}
 				</div>
 			</div>
 		</div>
@@ -116,13 +152,13 @@ const headings = rendered?.headings ?? [];
 								Resources
 							</h3>
 							<div class="flex flex-col gap-3">
-								<a href="#" class="flex items-center gap-2 text-sm text-slate-600 hover:text-nvidia-green transition-colors">
+								<a href={sourceUrl} target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 text-sm text-slate-600 hover:text-nvidia-green transition-colors">
 									<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
-									View Source Code
+									View Source
 								</a>
-								<a href="#" class="flex items-center gap-2 text-sm text-slate-600 hover:text-nvidia-green transition-colors">
+								<a href={issuesUrl} target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 text-sm text-slate-600 hover:text-nvidia-green transition-colors">
 									<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-									Ask for Help
+									Report Issue
 								</a>
 							</div>
 						</div>

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,138 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const SITE = 'https://www.jetson-ai-lab.com';
+
+const TUTORIAL_SLUG_MAP: Record<string, string> = {
+	'applications/jetson-platform-services': 'jetson-platform-services',
+	'applications/live-vlm-webui': 'live-vlm-webui',
+	'applications/nanoowl': 'nanoowl',
+	'applications/openclaw': 'openclaw',
+	'fundamentals/gemma4-on-jetson': 'gemma4-on-jetson',
+	'fundamentals/genai-benchmarking': 'genai-benchmarking',
+	'fundamentals/genai-on-jetson-llms-vlms': 'genai-on-jetson-llms-vlms',
+	'fundamentals/ollama': 'ollama',
+	'model-optimization/finetune-on-jetson': 'finetune-on-jetson',
+	'model-optimization/tensorrt-edge-llm': 'tensorrt-edge-llm',
+	'setup/initial-setup-jetson-orin-nano': 'initial-setup-jetson-orin-nano',
+	'setup/initial-setup-sdk-manager': 'initial-setup-sdk-manager',
+	'setup/ram-optimization': 'ram-optimization',
+	'setup/ssd-docker-setup': 'ssd-docker-setup',
+	'vla/openpi_on_thor': 'openpi_on_thor',
+	'vlm/cosmos-reason2-vlm': 'cosmos-reason2-vlm',
+	'workshops/gtc26': 'gtc26',
+	'workshops/hackathon-guide': 'hackathon-guide',
+	'workshops/workshop-gtc-dc-2025': 'workshop-gtc-dc-2025',
+};
+
+function tutorialUrl(slug: string): string {
+	const mapped = TUTORIAL_SLUG_MAP[slug] ?? slug.split('/').pop();
+	return `${SITE}/tutorials/${mapped}/`;
+}
+
+export const GET: APIRoute = async () => {
+	const tutorials = await getCollection('tutorials');
+	const models = await getCollection('models');
+
+	const sections: string[] = [];
+
+	sections.push(`# Jetson AI Lab — Full Documentation`);
+	sections.push('');
+	sections.push(
+		`> Complete reference for deploying generative AI on NVIDIA Jetson edge devices (Orin Nano, AGX Orin, Thor). This file contains the full text of all tutorials and model documentation.`
+	);
+	sections.push('');
+	sections.push(`Generated: ${new Date().toISOString().split('T')[0]}`);
+	sections.push(`Source: ${SITE}`);
+	sections.push('');
+
+	const categoryOrder = [
+		'Setup',
+		'Fundamentals',
+		'Model Optimization',
+		'Applications',
+		'VLM',
+		'VLA',
+		'Workshops',
+	];
+
+	const grouped = new Map<string, typeof tutorials>();
+	for (const cat of categoryOrder) {
+		grouped.set(cat, []);
+	}
+	for (const t of tutorials) {
+		const list = grouped.get(t.data.category) ?? [];
+		list.push(t);
+		grouped.set(t.data.category, list);
+	}
+
+	sections.push('---');
+	sections.push('');
+	sections.push('## Tutorials');
+	sections.push('');
+
+	for (const [category, items] of grouped) {
+		if (items.length === 0) continue;
+		items.sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
+
+		sections.push(`### ${category}`);
+		sections.push('');
+
+		for (const tutorial of items) {
+			const url = tutorialUrl(tutorial.slug);
+			const { Content } = await tutorial.render();
+
+			sections.push(`#### ${tutorial.data.title}`);
+			sections.push('');
+			sections.push(`URL: ${url}`);
+			sections.push(`Description: ${tutorial.data.description}`);
+			if (tutorial.data.tags?.length) {
+				sections.push(`Tags: ${tutorial.data.tags.join(', ')}`);
+			}
+			sections.push('');
+			sections.push(tutorial.body ?? '');
+			sections.push('');
+			sections.push('---');
+			sections.push('');
+		}
+	}
+
+	sections.push('## Supported Models');
+	sections.push('');
+
+	const sortedModels = [...models].sort((a, b) =>
+		a.data.title.localeCompare(b.data.title)
+	);
+
+	for (const model of sortedModels) {
+		sections.push(`### ${model.data.title}`);
+		sections.push('');
+		sections.push(`URL: ${SITE}/models/${model.slug}/`);
+		sections.push(`Description: ${model.data.short_description}`);
+		sections.push(`Memory: ${model.data.memory_requirements}`);
+		sections.push(`Precision: ${model.data.precision}`);
+		sections.push(`Size: ${model.data.model_size}`);
+		if (model.data.vision_capable) {
+			sections.push(`Vision capable: yes`);
+		}
+		if (model.data.hf_checkpoint) {
+			sections.push(`HuggingFace: ${model.data.hf_checkpoint}`);
+		}
+		sections.push('');
+		if (model.body?.trim()) {
+			sections.push(model.body);
+			sections.push('');
+		}
+		sections.push('---');
+		sections.push('');
+	}
+
+	const body = sections.join('\n');
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'Cache-Control': 'public, max-age=3600',
+		},
+	});
+};


### PR DESCRIPTION
Display authors as clickable avatar chips in tutorial hero section
<img width="674" height="308" alt="image" src="https://github.com/user-attachments/assets/069d44d9-1d15-4faa-8893-ede2383984ee" />

Wire View Source sidebar link to the tutorials GitHub repo file
<img width="271" height="81" alt="image" src="https://github.com/user-attachments/assets/edce0729-7098-4556-abb2-7a650f8361d4" />


Content discovery map for LLMs
- llms.txt (static, curated)
Location: public/llms.txt → served at jetson-ai-lab.com/llms.txt

- llms-full.txt (auto-generated at build time)
Location: src/pages/llms-full.txt.ts → served at jetson-ai-lab.com/llms-full.txt