### PR TITLE
feat: add benchmark section to model pages with multi-engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Desktop.ini
 # IDE / Editor
 .vscode/
 .idea/
+.cursor/
 *.swp
 *.swo
 *~
@@ -66,4 +67,13 @@ coverage/
 # Misc
 *.pem
 .certificates/
+
+# Screenshot / browser automation outputs (agent tooling, not site assets)
+.playwright-mcp/
+screenshots/
+.screenshots/
+
+# Merge/rebase scratch dirs and AI working files
+_merge_backup/
+*.md.bak
 

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -1,93 +1,411 @@
 ---
-import type { SupportedEngineEntry } from '../lib/inferenceCommands';
+const PRODUCTS = [
+	{ id: 't5000',         label: 'T5000' },
+	{ id: 't4000',         label: 'T4000' },
+	{ id: 'agx_orin_64gb', label: 'AGX Orin\n64GB' },
+	{ id: 'orin_nx_16gb',  label: 'Orin NX\n16GB' },
+	{ id: 'orin_nano_8gb', label: 'Orin Nano\n8GB' },
+] as const;
 
-interface BenchRow {
-	concurrency1: number;
-	concurrency8: number;
-	ttftMs?: number;
+type ProductId = (typeof PRODUCTS)[number]['id'];
+
+interface EngineData {
+	concurrency1: Partial<Record<ProductId, number | null>>;
+	concurrency8: Partial<Record<ProductId, number | null>>;
+}
+
+interface BenchmarkEntry {
+	name: string;
+	quantization: string;
+	isl: number | null;
+	osl: number | null;
+	engines: Record<string, EngineData>;
 }
 
 interface Props {
-	benchmark: Record<string, BenchRow | undefined>;
-	engines: SupportedEngineEntry[];
+	entry: BenchmarkEntry;
+	seriesEntries?: BenchmarkEntry[];
 }
 
-const { benchmark, engines } = Astro.props;
+const { entry, seriesEntries = [] } = Astro.props;
+const { quantization, isl, osl } = entry;
+const unit = isl !== null ? 'tok/s' : 'inf/s';
 
-const hasVllm = engines.some(
-	(e) => e.engine.toLowerCase().replace(/[.\-_]/g, '') === 'vllm',
+const allModels = [entry, ...seriesEntries];
+
+// Color palette: main model = NVIDIA green, series = progressively paler gray
+const MAIN_COLOR = '#76B900';
+const SERIES_COLORS = ['#ADADAD', '#C8C8C8', '#DEDEDE'];
+const modelColors = allModels.map((_, i) =>
+	i === 0 ? MAIN_COLOR : (SERIES_COLORS[i - 1] ?? SERIES_COLORS[SERIES_COLORS.length - 1]),
 );
 
-const orin = benchmark.orin;
-const thor = benchmark.thor;
-const hasAny = !!(orin || thor);
+// Collect all engine names across all models (preserving first-seen order)
+const engineNames: string[] = [];
+for (const m of allModels) {
+	for (const e of Object.keys(m.engines)) {
+		if (!engineNames.includes(e)) engineNames.push(e);
+	}
+}
+
+const hasAnyData = allModels.some((m) =>
+	Object.values(m.engines).some((eng) =>
+		PRODUCTS.some(
+			(p) =>
+				(eng.concurrency1[p.id] ?? null) !== null ||
+				(eng.concurrency8[p.id] ?? null) !== null,
+		),
+	),
+);
+
+const clientData = hasAnyData
+	? {
+			unit,
+			engineNames,
+			models: allModels.map((m, i) => ({
+				name: m.name,
+				color: modelColors[i],
+				isMain: i === 0,
+				engines: Object.fromEntries(
+					Object.entries(m.engines).map(([eng, data]) => [
+						eng,
+						{
+							c1: Object.fromEntries(PRODUCTS.map((p) => [p.id, data.concurrency1[p.id] ?? null])),
+							c8: Object.fromEntries(PRODUCTS.map((p) => [p.id, data.concurrency8[p.id] ?? null])),
+						},
+					]),
+				),
+			})),
+			products: PRODUCTS.map((p) => ({ id: p.id, label: p.label })),
+		}
+	: null;
+
+const firstEngine = engineNames[0] ?? '';
 ---
 
-{
-	hasAny && hasVllm && (
-		<section
-			id="model-benchmark"
-			class="py-16 bg-white border-b border-nvidia-gray-200 scroll-mt-20"
-			aria-labelledby="model-benchmark-heading"
-		>
-			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-				<h2 id="model-benchmark-heading" class="text-3xl font-bold text-nvidia-black mb-2">
-					Benchmark
-				</h2>
-				<p class="text-sm text-nvidia-gray-600 max-w-3xl mb-8">
-					Throughput numbers below were measured with vLLM on Jetson under the lab&apos;s test setup.
-					Your results will vary with image, clocks, and workload.
-				</p>
+{hasAnyData && (
+	<section
+		id="model-benchmark"
+		class="py-16 bg-white border-b border-nvidia-gray-200 scroll-mt-20"
+		aria-labelledby="model-benchmark-heading"
+	>
+		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 
-				<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-					{orin && (
-						<div class="rounded-xl border border-nvidia-gray-200 bg-nvidia-gray-50/80 p-6">
-							<h3 class="text-sm font-semibold text-nvidia-gray-500 uppercase tracking-wide mb-4">
-								Jetson Orin (vLLM)
-							</h3>
-							<div class="grid grid-cols-2 gap-4">
-								<div class="bg-white rounded-lg p-4 border border-nvidia-gray-100">
-									<div class="text-3xl font-bold text-nvidia-green text-center">{orin.concurrency1}</div>
-									<div class="text-sm text-nvidia-gray-600 mt-2 text-center">tokens/sec (concurrency 1)</div>
-								</div>
-								<div class="bg-white rounded-lg p-4 border border-nvidia-gray-100">
-									<div class="text-3xl font-bold text-nvidia-green text-center">{orin.concurrency8}</div>
-									<div class="text-sm text-nvidia-gray-600 mt-2 text-center">tokens/sec (concurrency 8)</div>
-								</div>
-							</div>
-							{orin.ttftMs != null && orin.ttftMs > 0 && (
-								<div class="mt-4 bg-white rounded-lg p-4 border border-nvidia-gray-100 text-center">
-									<div class="text-2xl font-bold text-nvidia-black">{orin.ttftMs} ms</div>
-									<div class="text-sm text-nvidia-gray-600 mt-1">Time to first token</div>
-								</div>
-							)}
+			{/* Header */}
+			<div class="flex flex-wrap items-start justify-between gap-4 mb-6">
+				<div>
+					<h2 id="model-benchmark-heading" class="text-3xl font-bold text-nvidia-black mb-1">
+						Benchmark
+					</h2>
+					<p class="text-sm text-nvidia-gray-500">
+						<span id="bench-engine-label">{firstEngine}</span>
+						{quantization && <>&nbsp;&middot;&nbsp;<span class="font-mono">{quantization}</span></>}
+						{isl != null && <>&nbsp;&middot;&nbsp;ISL&nbsp;{isl}&nbsp;/&nbsp;OSL&nbsp;{osl}</>}
+					</p>
+				</div>
+				<div class="flex flex-wrap items-center gap-2 self-start mt-1">
+					{/* Engine toggle — only rendered when >1 engine has data */}
+					{engineNames.length > 1 && (
+						<div
+							id="bench-engine-toggle"
+							class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
+							aria-label="Inference engine selector"
+						>
+							{engineNames.map((e) => (
+								<button
+									class={`px-4 py-1.5 text-xs font-semibold rounded-md transition-all duration-150 ${e === firstEngine ? 'bg-white text-nvidia-black shadow-sm' : 'text-nvidia-gray-600 hover:bg-nvidia-gray-200'}`}
+									data-engine={e}
+								>
+									{e}
+								</button>
+							))}
 						</div>
 					)}
-					{thor && (
-						<div class="rounded-xl border border-nvidia-gray-200 bg-nvidia-gray-50/80 p-6">
-							<h3 class="text-sm font-semibold text-nvidia-gray-500 uppercase tracking-wide mb-4">
-								Jetson Thor (vLLM)
-							</h3>
-							<div class="grid grid-cols-2 gap-4">
-								<div class="bg-white rounded-lg p-4 border border-nvidia-gray-100">
-									<div class="text-3xl font-bold text-nvidia-green text-center">{thor.concurrency1}</div>
-									<div class="text-sm text-nvidia-gray-600 mt-2 text-center">tokens/sec (concurrency 1)</div>
-								</div>
-								<div class="bg-white rounded-lg p-4 border border-nvidia-gray-100">
-									<div class="text-3xl font-bold text-nvidia-green text-center">{thor.concurrency8}</div>
-									<div class="text-sm text-nvidia-gray-600 mt-2 text-center">tokens/sec (concurrency 8)</div>
-								</div>
-							</div>
-							{thor.ttftMs != null && thor.ttftMs > 0 && (
-								<div class="mt-4 bg-white rounded-lg p-4 border border-nvidia-gray-100 text-center">
-									<div class="text-2xl font-bold text-nvidia-black">{thor.ttftMs} ms</div>
-									<div class="text-sm text-nvidia-gray-600 mt-1">Time to first token</div>
-								</div>
-							)}
-						</div>
-					)}
+					{/* Concurrency toggle */}
+					<div
+						class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
+						aria-label="Concurrency selector"
+					>
+						<button
+							id="bench-btn-c1"
+							class="px-4 py-1.5 text-xs font-semibold rounded-md bg-nvidia-green text-nvidia-black shadow-sm transition-all duration-150"
+						>
+							C=1
+						</button>
+						<button
+							id="bench-btn-c8"
+							class="px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150"
+						>
+							C=8
+						</button>
+					</div>
 				</div>
 			</div>
-		</section>
-	)
-}
+
+			{/* Legend — only shown when series models are present */}
+			{seriesEntries.length > 0 && (
+				<div class="flex flex-wrap gap-x-5 gap-y-2 mb-5">
+					{allModels.map((m, i) => (
+						<div class="flex items-center gap-2">
+							<span
+								class="inline-block w-3.5 h-3.5 rounded-sm shrink-0"
+								style={`background:${modelColors[i]};border:1px solid rgba(0,0,0,0.1)`}
+							/>
+							<span class="text-xs text-nvidia-gray-700">
+								{m.name}
+								{i === 0 && <span class="text-nvidia-gray-400 ml-1">(this model)</span>}
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* Chart container */}
+			<div class="relative overflow-x-auto rounded-xl border border-nvidia-gray-100 bg-white">
+				<div id="bench-chart" class="min-w-[400px]" />
+				<div
+					id="bench-tooltip"
+					class="hidden absolute pointer-events-none bg-nvidia-black text-white text-xs px-3 py-2 rounded-lg shadow-lg whitespace-nowrap z-10"
+					style="transform:translate(12px,-50%)"
+				/>
+			</div>
+			<div id="bench-no-data" class="hidden py-10 text-center text-sm text-nvidia-gray-400">
+				No data available for this combination.
+			</div>
+
+			<p class="mt-5 text-[11px] text-nvidia-gray-400">
+				C = concurrent requests. Results will vary with image, clocks, and workload.
+			</p>
+		</div>
+	</section>
+)}
+
+<script define:vars={{ benchData: clientData }}>
+	if (!benchData) return;
+
+	let conc = 'c1';
+	let currentEngine = benchData.engineNames[0];
+	let yAxisFixed = false;
+
+	const chartEl = document.getElementById('bench-chart');
+	const wrap = chartEl.parentElement;
+	const tooltip = document.getElementById('bench-tooltip');
+	const noDataEl = document.getElementById('bench-no-data');
+	const engineLabelEl = document.getElementById('bench-engine-label');
+
+	function getEffectiveModels() {
+		return benchData.models.map((m) => ({
+			name: m.name,
+			color: m.color,
+			isMain: m.isMain,
+			c1: m.engines[currentEngine]?.c1 ?? {},
+			c8: m.engines[currentEngine]?.c8 ?? {},
+		}));
+	}
+
+	function niceMax(max) {
+		if (max <= 0) return 100;
+		const p = max * 1.15;
+		const exp = Math.floor(Math.log10(p));
+		const mag = Math.pow(10, exp);
+		const n = p / mag;
+		let nice;
+		if (n <= 1.5) nice = 1.5;
+		else if (n <= 2) nice = 2;
+		else if (n <= 2.5) nice = 2.5;
+		else if (n <= 3) nice = 3;
+		else if (n <= 4) nice = 4;
+		else if (n <= 5) nice = 5;
+		else if (n <= 7.5) nice = 7.5;
+		else nice = 10;
+		return nice * mag;
+	}
+
+	// Global Y max across all engines × concurrencies × products (used when axis is locked)
+	const globalYMax = niceMax(Math.max(
+		...benchData.models.flatMap((m) =>
+			benchData.engineNames.flatMap((eng) =>
+				benchData.products.map((p) => Math.max(
+					m.engines[eng]?.c1[p.id] ?? 0,
+					m.engines[eng]?.c8[p.id] ?? 0,
+				))
+			)
+		),
+		1,
+	));
+
+	function render() {
+		const models = getEffectiveModels();
+		const key = conc; // 'c1' | 'c8'
+
+		const activeProducts = benchData.products.filter((p) =>
+			models.some((m) => m[key][p.id] != null),
+		);
+
+		if (activeProducts.length === 0) {
+			chartEl.innerHTML = '';
+			noDataEl.classList.remove('hidden');
+			updateBtns();
+			return;
+		}
+		noDataEl.classList.add('hidden');
+
+		const allVals = models.flatMap((m) =>
+			activeProducts.map((p) => m[key][p.id] ?? 0),
+		);
+		const yMax = yAxisFixed ? globalYMax : niceMax(Math.max(...allVals, 1));
+
+		// Layout — mt=28 reserves space above the chart area for the Y-lock button
+		const ml = 62, mr = 24, mt = 28, mb = 68;
+		const N = activeProducts.length;
+		const M = models.length;
+
+		const groupW = Math.max(140, Math.min(260, 1100 / N));
+		const W = ml + N * groupW + mr;
+		const chartH = 320;
+		const H = mt + chartH + mb;
+
+		const barW = Math.min(44, Math.max(16, (groupW * 0.52) / M));
+		const barGap = Math.max(3, barW * 0.14);
+		const groupBarSpan = M * barW + (M - 1) * barGap;
+
+		const yScale = (v) => mt + chartH - (v / yMax) * chartH;
+		const groupCx = (i) => ml + (i + 0.5) * groupW;
+		const barLeft = (gi, bi) =>
+			groupCx(gi) - groupBarSpan / 2 + bi * (barW + barGap);
+
+		let s = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"
+			style="display:block;width:100%;max-width:${W}px;height:auto;margin:0 auto;font-family:system-ui,-apple-system,sans-serif">
+			<style>
+				.bbar{transform-box:fill-box;transform-origin:50% 100%;animation:bbar-in 0.4s cubic-bezier(.25,.46,.45,.94) both}
+				@keyframes bbar-in{from{transform:scaleY(0)}}
+			</style>`;
+
+		// Lock button — positioned in top margin just left of the Y axis top
+		// Open padlock = auto-scale (default); closed padlock = Y axis fixed
+		const lbX = ml - 20, lbY = 5, lbS = 18;
+		const lkCol = yAxisFixed ? '#374151' : '#C4C4C4';
+		const lkBg  = yAxisFixed ? '#F3F4F6' : 'white';
+		const lkTip = yAxisFixed ? 'Auto-scale Y axis' : 'Fix Y-axis scale';
+		const lkShackle = yAxisFixed
+			? `M4 7.5V5a3 3 0 0 1 6 0v2.5`
+			: `M4 7.5V5a3 3 0 0 1 6 0`;
+		s += `<g class="bench-lock-btn" style="cursor:pointer">
+			<rect x="${lbX}" y="${lbY}" width="${lbS}" height="${lbS}" rx="3" fill="${lkBg}" stroke="#E5E7EB"/>
+			<g transform="translate(${lbX + 2.5},${lbY + 1.5})" stroke="${lkCol}" stroke-linecap="round" stroke-linejoin="round" fill="none" pointer-events="none">
+				<rect x="0.5" y="7" width="12" height="8.5" rx="1.5" fill="${lkCol}" stroke="none"/>
+				<path d="${lkShackle}" stroke-width="1.5"/>
+				<circle cx="6.5" cy="11.5" r="1.1" fill="${lkBg}" stroke="none"/>
+			</g>
+			<rect x="${lbX}" y="${lbY}" width="${lbS}" height="${lbS}" rx="3" fill="transparent" data-tip="${lkTip}"/>
+		</g>`;
+
+		// Y gridlines + labels
+		const yTicks = 5;
+		const yStep = yMax / yTicks;
+		for (let i = 0; i <= yTicks; i++) {
+			const v = Math.round(yStep * i);
+			const cy = yScale(v);
+			s += `<line x1="${ml}" y1="${cy}" x2="${ml + N * groupW}" y2="${cy}" stroke="${i === 0 ? '#E5E7EB' : '#F3F4F6'}"/>`;
+			s += `<text x="${ml - 7}" y="${cy}" text-anchor="end" dominant-baseline="middle" fill="#9CA3AF" font-size="11">${v}</text>`;
+		}
+
+		// Y-axis title
+		s += `<text x="12" y="${mt + chartH / 2}" text-anchor="middle" dominant-baseline="middle" fill="#9CA3AF" font-size="11" transform="rotate(-90,12,${mt + chartH / 2})">${benchData.unit}</text>`;
+
+		// Axis lines
+		s += `<line x1="${ml}" y1="${mt}" x2="${ml}" y2="${mt + chartH}" stroke="#E5E7EB"/>`;
+		s += `<line x1="${ml}" y1="${mt + chartH}" x2="${ml + N * groupW}" y2="${mt + chartH}" stroke="#E5E7EB"/>`;
+
+		// Groups
+		activeProducts.forEach((prod, gi) => {
+			const cx = groupCx(gi);
+
+			if (gi > 0) {
+				s += `<line x1="${ml + gi * groupW}" y1="${mt}" x2="${ml + gi * groupW}" y2="${mt + chartH}" stroke="#F9FAFB" stroke-dasharray="3 3"/>`;
+			}
+
+			const parts = prod.label.split('\n');
+			const ly = mt + chartH + 18;
+			s += `<text x="${cx}" y="${ly}" text-anchor="middle" fill="#6B7280" font-size="12" font-weight="500">${parts[0]}</text>`;
+			if (parts[1]) {
+				s += `<text x="${cx}" y="${ly + 15}" text-anchor="middle" fill="#6B7280" font-size="12">${parts[1]}</text>`;
+			}
+
+			models.forEach((model, bi) => {
+				const val = model[key][prod.id];
+				if (val == null) return;
+
+				const x = barLeft(gi, bi);
+				const bh = (val / yMax) * chartH;
+				const by = mt + chartH - bh;
+				const rx = Math.min(3, barW / 5);
+
+				s += `<rect x="${x + 1}" y="${by + 2}" width="${barW}" height="${bh}" fill="black" opacity="0.05" rx="${rx}"/>`;
+				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${model.color}" rx="${rx}"
+					class="bbar" style="cursor:pointer;animation-delay:${bi * 40}ms"
+					data-tip="${model.name}: ${val} ${benchData.unit}"/>`;
+				if (bh > 20) {
+					s += `<text x="${x + barW / 2}" y="${by - 4}" text-anchor="middle"
+						fill="${model.isMain ? '#374151' : '#9CA3AF'}" font-size="9.5" font-weight="${model.isMain ? '600' : '400'}">${val}</text>`;
+				}
+			});
+		});
+
+		s += '</svg>';
+		chartEl.innerHTML = s;
+		updateBtns();
+		attachHover();
+	}
+
+	function attachHover() {
+		chartEl.querySelectorAll('[data-tip]').forEach((el) => {
+			el.addEventListener('mouseenter', (e) => {
+				if (!el.closest('.bench-lock-btn')) el.setAttribute('opacity', '0.82');
+				tooltip.textContent = el.dataset.tip;
+				tooltip.classList.remove('hidden');
+				posTooltip(e);
+			});
+			el.addEventListener('mousemove', posTooltip);
+			el.addEventListener('mouseleave', () => {
+				el.removeAttribute('opacity');
+				tooltip.classList.add('hidden');
+			});
+		});
+	}
+
+	function posTooltip(e) {
+		const r = wrap.getBoundingClientRect();
+		tooltip.style.left = e.clientX - r.left + 14 + 'px';
+		tooltip.style.top = e.clientY - r.top + 'px';
+	}
+
+	function updateBtns() {
+		const onC = 'px-4 py-1.5 text-xs font-semibold rounded-md bg-nvidia-green text-nvidia-black shadow-sm transition-all duration-150';
+		const offC = 'px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150';
+		document.getElementById('bench-btn-c1').className = conc === 'c1' ? onC : offC;
+		document.getElementById('bench-btn-c8').className = conc === 'c8' ? onC : offC;
+
+		const onE = 'px-4 py-1.5 text-xs font-semibold rounded-md bg-white text-nvidia-black shadow-sm transition-all duration-150';
+		const offE = 'px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150';
+		document.querySelectorAll('#bench-engine-toggle [data-engine]').forEach((btn) => {
+			btn.className = btn.dataset.engine === currentEngine ? onE : offE;
+		});
+
+		if (engineLabelEl) engineLabelEl.textContent = currentEngine;
+	}
+
+	document.getElementById('bench-btn-c1').addEventListener('click', () => { conc = 'c1'; render(); });
+	document.getElementById('bench-btn-c8').addEventListener('click', () => { conc = 'c8'; render(); });
+
+	document.querySelectorAll('#bench-engine-toggle [data-engine]').forEach((btn) => {
+		btn.addEventListener('click', () => { currentEngine = btn.dataset.engine; render(); });
+	});
+
+	// Lock button uses event delegation since SVG is rebuilt on each render
+	chartEl.addEventListener('click', (e) => {
+		if (e.target.closest('.bench-lock-btn')) { yAxisFixed = !yAxisFixed; render(); }
+	});
+
+	render();
+</script>

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -104,8 +104,8 @@ const firstEngine = engineNames[0] ?? '';
 					</p>
 				</div>
 				<div class="flex flex-wrap items-center gap-2 self-start mt-1">
-					{/* Engine toggle — only rendered when >1 engine has data */}
-					{engineNames.length > 1 && (
+					{/* Engine toggle — always shown so users know which engine the benchmark used */}
+					{engineNames.length > 0 && (
 						<div
 							id="bench-engine-toggle"
 							class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
@@ -289,6 +289,9 @@ const firstEngine = engineNames[0] ?? '';
 				<filter id="ebar-glow" x="-80%" y="-80%" width="260%" height="260%">
 					<feGaussianBlur in="SourceGraphic" stdDeviation="7"/>
 				</filter>
+				<filter id="bar-shadow" x="-20%" y="-10%" width="160%" height="140%">
+					<feGaussianBlur in="SourceGraphic" stdDeviation="2.5"/>
+				</filter>
 			</defs>
 			<style>
 				.bbar{transform-box:fill-box;transform-origin:50% 100%;animation:bbar-in 0.4s cubic-bezier(.25,.46,.45,.94) both}
@@ -357,7 +360,7 @@ const firstEngine = engineNames[0] ?? '';
 
 				const gp = 5; // glow padding beyond bar edges
 				s += `<rect x="${x - gp}" y="${by - gp}" width="${barW + gp * 2}" height="${bh + gp * 2}" fill="${engineHue}" opacity="0.35" rx="${rx + 2}" filter="url(#ebar-glow)"/>`;
-				s += `<rect x="${x + 1}" y="${by + 2}" width="${barW}" height="${bh}" fill="black" opacity="0.05" rx="${rx}"/>`;
+				s += `<rect x="${x + 3}" y="${by + 4}" width="${barW}" height="${bh}" fill="black" opacity="0.13" rx="${rx}" filter="url(#bar-shadow)"/>`;
 				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${model.color}" rx="${rx}"
 					class="bbar" style="cursor:pointer;animation-delay:${bi * 40}ms"
 					data-tip="${model.name}: ${val} ${benchData.unit}"/>`;

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -187,6 +187,13 @@ const firstEngine = engineNames[0] ?? '';
 	let currentEngine = benchData.engineNames[0];
 	let yAxisFixed = false;
 
+	const ENGINE_COLORS = {
+		'vLLM':      '#30a3ff',
+		'SGLang':    '#d55816',
+		'llama.cpp': '#1b1f20',
+		'Edge-LLM':  '#006666',
+	};
+
 	const chartEl = document.getElementById('bench-chart');
 	const wrap = chartEl.parentElement;
 	const tooltip = document.getElementById('bench-tooltip');
@@ -274,8 +281,15 @@ const firstEngine = engineNames[0] ?? '';
 		const barLeft = (gi, bi) =>
 			groupCx(gi) - groupBarSpan / 2 + bi * (barW + barGap);
 
+		const engineHue = ENGINE_COLORS[currentEngine] ?? '#888888';
+
 		let s = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"
 			style="display:block;width:100%;max-width:${W}px;height:auto;margin:0 auto;font-family:system-ui,-apple-system,sans-serif">
+			<defs>
+				<filter id="ebar-glow" x="-80%" y="-80%" width="260%" height="260%">
+					<feGaussianBlur in="SourceGraphic" stdDeviation="7"/>
+				</filter>
+			</defs>
 			<style>
 				.bbar{transform-box:fill-box;transform-origin:50% 100%;animation:bbar-in 0.4s cubic-bezier(.25,.46,.45,.94) both}
 				@keyframes bbar-in{from{transform:scaleY(0)}}
@@ -341,6 +355,8 @@ const firstEngine = engineNames[0] ?? '';
 				const by = mt + chartH - bh;
 				const rx = Math.min(3, barW / 5);
 
+				const gp = 5; // glow padding beyond bar edges
+				s += `<rect x="${x - gp}" y="${by - gp}" width="${barW + gp * 2}" height="${bh + gp * 2}" fill="${engineHue}" opacity="0.35" rx="${rx + 2}" filter="url(#ebar-glow)"/>`;
 				s += `<rect x="${x + 1}" y="${by + 2}" width="${barW}" height="${bh}" fill="black" opacity="0.05" rx="${rx}"/>`;
 				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${model.color}" rx="${rx}"
 					class="bbar" style="cursor:pointer;animation-delay:${bi * 40}ms"

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -290,7 +290,7 @@ const firstEngine = engineNames[0] ?? '';
 					<feGaussianBlur in="SourceGraphic" stdDeviation="7"/>
 				</filter>
 				<filter id="bar-shadow" x="-5%" y="-5%" width="135%" height="140%">
-					<feDropShadow dx="3" dy="4" stdDeviation="2" flood-color="black" flood-opacity="0.18"/>
+					<feDropShadow dx="5" dy="6" stdDeviation="1" flood-color="black" flood-opacity="0.22"/>
 				</filter>
 			</defs>
 			<style>

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -9,17 +9,17 @@ const PRODUCTS = [
 
 type ProductId = (typeof PRODUCTS)[number]['id'];
 
-interface EngineData {
+interface QuantData {
 	concurrency1: Partial<Record<ProductId, number | null>>;
 	concurrency8: Partial<Record<ProductId, number | null>>;
 }
 
 interface BenchmarkEntry {
 	name: string;
-	quantization: string;
 	isl: number | null;
 	osl: number | null;
-	engines: Record<string, EngineData>;
+	/** engines[engineName][quantName] = QuantData */
+	engines: Record<string, Record<string, QuantData>>;
 }
 
 interface Props {
@@ -28,7 +28,7 @@ interface Props {
 }
 
 const { entry, seriesEntries = [] } = Astro.props;
-const { quantization, isl, osl } = entry;
+const { isl, osl } = entry;
 const unit = isl !== null ? 'tok/s' : 'inf/s';
 
 const allModels = [entry, ...seriesEntries];
@@ -49,11 +49,13 @@ for (const m of allModels) {
 }
 
 const hasAnyData = allModels.some((m) =>
-	Object.values(m.engines).some((eng) =>
-		PRODUCTS.some(
-			(p) =>
-				(eng.concurrency1[p.id] ?? null) !== null ||
-				(eng.concurrency8[p.id] ?? null) !== null,
+	Object.values(m.engines).some((quants) =>
+		Object.values(quants).some((qd) =>
+			PRODUCTS.some(
+				(p) =>
+					(qd.concurrency1[p.id] ?? null) !== null ||
+					(qd.concurrency8[p.id] ?? null) !== null,
+			),
 		),
 	),
 );
@@ -67,12 +69,17 @@ const clientData = hasAnyData
 				color: modelColors[i],
 				isMain: i === 0,
 				engines: Object.fromEntries(
-					Object.entries(m.engines).map(([eng, data]) => [
+					Object.entries(m.engines).map(([eng, quants]) => [
 						eng,
-						{
-							c1: Object.fromEntries(PRODUCTS.map((p) => [p.id, data.concurrency1[p.id] ?? null])),
-							c8: Object.fromEntries(PRODUCTS.map((p) => [p.id, data.concurrency8[p.id] ?? null])),
-						},
+						Object.fromEntries(
+							Object.entries(quants).map(([quant, qd]) => [
+								quant,
+								{
+									c1: Object.fromEntries(PRODUCTS.map((p) => [p.id, qd.concurrency1[p.id] ?? null])),
+									c8: Object.fromEntries(PRODUCTS.map((p) => [p.id, qd.concurrency8[p.id] ?? null])),
+								},
+							]),
+						),
 					]),
 				),
 			})),
@@ -81,6 +88,16 @@ const clientData = hasAnyData
 	: null;
 
 const firstEngine = engineNames[0] ?? '';
+// For subtitle: quant names of first engine of main entry
+const firstEngineQuants = Object.keys(entry.engines[firstEngine] ?? {});
+const firstEngineQuantLabel = firstEngineQuants.join(' / ');
+
+const ENGINE_COLORS_MAP: Record<string, string> = {
+	'vLLM':      '#30a3ff',
+	'SGLang':    '#d55816',
+	'llama.cpp': '#8899A6',
+	'Edge-LLM':  '#006666',
+};
 ---
 
 {hasAnyData && (
@@ -99,66 +116,59 @@ const firstEngine = engineNames[0] ?? '';
 					</h2>
 					<p class="text-sm text-nvidia-gray-500">
 						<span id="bench-engine-label">{firstEngine}</span>
-						{quantization && <>&nbsp;&middot;&nbsp;<span class="font-mono">{quantization}</span></>}
+						<span id="bench-quant-wrapper" class={firstEngineQuantLabel ? '' : 'hidden'}>
+							&nbsp;&middot;&nbsp;<span id="bench-quant-label" class="font-mono">{firstEngineQuantLabel}</span>
+						</span>
 						{isl != null && <>&nbsp;&middot;&nbsp;ISL&nbsp;{isl}&nbsp;/&nbsp;OSL&nbsp;{osl}</>}
 					</p>
 				</div>
-				<div class="flex flex-wrap items-center gap-2 self-start mt-1">
-					{/* Engine toggle — always shown so users know which engine the benchmark used */}
+				<div class="flex flex-wrap justify-end items-center gap-x-4 gap-y-2 self-start mt-1">
+					{/* Engine toggle */}
 					{engineNames.length > 0 && (
-						<div
-							id="bench-engine-toggle"
-							class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
-							aria-label="Inference engine selector"
-						>
-							{engineNames.map((e) => (
-								<button
-									class={`px-4 py-1.5 text-xs font-semibold rounded-md transition-all duration-150 ${e === firstEngine ? 'bg-white text-nvidia-black shadow-sm' : 'text-nvidia-gray-600 hover:bg-nvidia-gray-200'}`}
-									data-engine={e}
-								>
-									{e}
-								</button>
-							))}
+						<div class="flex items-center gap-2">
+							<span class="text-xs text-nvidia-gray-400 font-medium">Engine</span>
+							<div
+								id="bench-engine-toggle"
+								class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
+								aria-label="Inference engine selector"
+							>
+								{engineNames.map((e) => (
+									<button
+										class={`px-4 py-1.5 text-xs font-semibold rounded-md transition-all duration-150 ${e === firstEngine ? 'bg-nvidia-black text-white shadow-sm' : 'text-nvidia-gray-600 hover:bg-nvidia-gray-200'}`}
+										data-engine={e}
+									>
+										<span style={`border-bottom: 3px solid ${ENGINE_COLORS_MAP[e] ?? '#888888'}; padding-bottom: 1px;`}>{e}</span>
+									</button>
+								))}
+							</div>
 						</div>
 					)}
 					{/* Concurrency toggle */}
-					<div
-						class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
-						aria-label="Concurrency selector"
-					>
-						<button
-							id="bench-btn-c1"
-							class="px-4 py-1.5 text-xs font-semibold rounded-md bg-nvidia-green text-nvidia-black shadow-sm transition-all duration-150"
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-nvidia-gray-400 font-medium">Concurrency</span>
+						<div
+							class="inline-flex rounded-lg bg-nvidia-gray-100 p-0.5"
+							aria-label="Concurrency selector"
 						>
-							C=1
-						</button>
-						<button
-							id="bench-btn-c8"
-							class="px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150"
-						>
-							C=8
-						</button>
+							<button
+								id="bench-btn-c1"
+								class="px-4 py-1.5 text-xs font-semibold rounded-md bg-nvidia-green text-nvidia-black shadow-sm transition-all duration-150"
+							>
+								C=1
+							</button>
+							<button
+								id="bench-btn-c8"
+								class="px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150"
+							>
+								C=8
+							</button>
+						</div>
 					</div>
 				</div>
 			</div>
 
-			{/* Legend — only shown when series models are present */}
-			{seriesEntries.length > 0 && (
-				<div class="flex flex-wrap gap-x-5 gap-y-2 mb-5">
-					{allModels.map((m, i) => (
-						<div class="flex items-center gap-2">
-							<span
-								class="inline-block w-3.5 h-3.5 rounded-sm shrink-0"
-								style={`background:${modelColors[i]};border:1px solid rgba(0,0,0,0.1)`}
-							/>
-							<span class="text-xs text-nvidia-gray-700">
-								{m.name}
-								{i === 0 && <span class="text-nvidia-gray-400 ml-1">(this model)</span>}
-							</span>
-						</div>
-					))}
-				</div>
-			)}
+			{/* Legend — JS-rendered: quant swatches + series model names */}
+			<div id="bench-legend" class="flex flex-wrap gap-x-5 gap-y-2 mb-5 hidden" />
 
 			{/* Chart container */}
 			<div class="relative overflow-x-auto rounded-xl border border-nvidia-gray-100 bg-white">
@@ -190,7 +200,7 @@ const firstEngine = engineNames[0] ?? '';
 	const ENGINE_COLORS = {
 		'vLLM':      '#30a3ff',
 		'SGLang':    '#d55816',
-		'llama.cpp': '#1b1f20',
+		'llama.cpp': '#8899A6',
 		'Edge-LLM':  '#006666',
 	};
 
@@ -199,15 +209,36 @@ const firstEngine = engineNames[0] ?? '';
 	const tooltip = document.getElementById('bench-tooltip');
 	const noDataEl = document.getElementById('bench-no-data');
 	const engineLabelEl = document.getElementById('bench-engine-label');
+	const quantLabelEl = document.getElementById('bench-quant-label');
+	const quantWrapperEl = document.getElementById('bench-quant-wrapper');
 
-	function getEffectiveModels() {
-		return benchData.models.map((m) => ({
-			name: m.name,
-			color: m.color,
-			isMain: m.isMain,
-			c1: m.engines[currentEngine]?.c1 ?? {},
-			c8: m.engines[currentEngine]?.c8 ?? {},
-		}));
+	// Bar fill color per quantization tier
+	function getBarColor(quant) {
+		const q = quant.toUpperCase();
+		if (/Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]/.test(q)) return '#7C6FA0';              // GGUF quants → muted gray-purple
+		if (/FP4|INT4|W4|NF4|Q4|4.?BIT|AWQ|NVFP4|MXFP4/.test(q)) return '#A855F7'; // 4-bit → pale purple
+		if (/FP8|INT8|W8|Q8/.test(q)) return '#76B900';                               // 8-bit → NVIDIA green
+		return '#006666';                                                               // 16-bit → dark teal
+	}
+
+	// Build flat bar list: color encodes quant tier directly
+	function getBars() {
+		const main = benchData.models[0];
+		const mainQuants = main.engines[currentEngine] ?? {};
+		return [
+			...Object.keys(mainQuants).map((q) => ({
+				label: q,
+				color: getBarColor(q),
+				legendColor: getBarColor(q),
+				isMain: true,
+				c1: mainQuants[q]?.c1 ?? {},
+				c8: mainQuants[q]?.c8 ?? {},
+			})),
+			...benchData.models.slice(1).map((m) => {
+				const firstQuant = Object.values(m.engines[currentEngine] ?? {})[0] ?? { c1: {}, c8: {} };
+				return { label: m.name, color: m.color, legendColor: m.color, isMain: false, c1: firstQuant.c1, c8: firstQuant.c8 };
+			}),
+		];
 	}
 
 	function niceMax(max) {
@@ -228,44 +259,53 @@ const firstEngine = engineNames[0] ?? '';
 		return nice * mag;
 	}
 
-	// Global Y max across all engines × concurrencies × products (used when axis is locked)
+	// Global Y max across all engines × quants × concurrencies × products (used when axis is locked)
 	const globalYMax = niceMax(Math.max(
 		...benchData.models.flatMap((m) =>
 			benchData.engineNames.flatMap((eng) =>
-				benchData.products.map((p) => Math.max(
-					m.engines[eng]?.c1[p.id] ?? 0,
-					m.engines[eng]?.c8[p.id] ?? 0,
-				))
+				Object.values(m.engines[eng] ?? {}).flatMap((qd) =>
+					benchData.products.flatMap((p) => [qd.c1[p.id] ?? 0, qd.c8[p.id] ?? 0])
+				)
 			)
 		),
 		1,
 	));
 
+	function renderLegend() {
+		const legendEl = document.getElementById('bench-legend');
+		if (!legendEl) return;
+		const bars = getBars();
+		legendEl.classList.remove('hidden');
+		legendEl.innerHTML = bars.map((b) =>
+			`<div class="flex items-center gap-2"><span class="inline-block w-3.5 h-3.5 rounded-sm shrink-0" style="background:${b.legendColor ?? b.color};border:1px solid rgba(0,0,0,0.1)"></span><span class="text-xs" style="color:#374151">${b.label}</span></div>`
+		).join('');
+	}
+
 	function render() {
-		const models = getEffectiveModels();
+		const bars = getBars();
 		const key = conc; // 'c1' | 'c8'
 
-		const activeProducts = benchData.products.filter((p) =>
-			models.some((m) => m[key][p.id] != null),
-		);
+		const activeProducts = benchData.products;
 
-		if (activeProducts.length === 0) {
+		const hasAny = bars.some((b) => activeProducts.some((p) => b[key][p.id] != null));
+		if (!hasAny) {
 			chartEl.innerHTML = '';
 			noDataEl.classList.remove('hidden');
 			updateBtns();
+			renderLegend();
 			return;
 		}
 		noDataEl.classList.add('hidden');
 
-		const allVals = models.flatMap((m) =>
-			activeProducts.map((p) => m[key][p.id] ?? 0),
+		const allVals = bars.flatMap((b) =>
+			activeProducts.map((p) => b[key][p.id] ?? 0),
 		);
 		const yMax = yAxisFixed ? globalYMax : niceMax(Math.max(...allVals, 1));
 
 		// Layout — mt=28 reserves space above the chart area for the Y-lock button
 		const ml = 62, mr = 24, mt = 28, mb = 68;
 		const N = activeProducts.length;
-		const M = models.length;
+		const M = bars.length;
 
 		const groupW = Math.max(140, Math.min(260, 1100 / N));
 		const W = ml + N * groupW + mr;
@@ -286,11 +326,21 @@ const firstEngine = engineNames[0] ?? '';
 		let s = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"
 			style="display:block;width:100%;max-width:${W}px;height:auto;margin:0 auto;font-family:system-ui,-apple-system,sans-serif">
 			<defs>
-				<filter id="ebar-glow" x="-80%" y="-80%" width="260%" height="260%">
-					<feGaussianBlur in="SourceGraphic" stdDeviation="7"/>
-				</filter>
-				<filter id="bar-shadow" x="-5%" y="-5%" width="135%" height="140%">
-					<feDropShadow dx="5" dy="6" stdDeviation="1" flood-color="black" flood-opacity="0.22"/>
+				<clipPath id="chart-clip">
+					<rect x="0" y="0" width="${W}" height="${mt + chartH}"/>
+				</clipPath>
+				<filter id="bar-shadow" x="-10%" y="-5%" width="140%" height="130%">
+					<feFlood flood-color="${engineHue}" flood-opacity="1" result="clr"/>
+					<feComposite in="clr" in2="SourceAlpha" operator="in" result="shape"/>
+					<feOffset dx="5" dy="6" in="shape" result="moved"/>
+					<feGaussianBlur in="moved" stdDeviation="2" result="blur"/>
+					<feComponentTransfer in="blur" result="shadow">
+						<feFuncA type="linear" slope="0.25"/>
+					</feComponentTransfer>
+					<feMerge>
+						<feMergeNode in="shadow"/>
+						<feMergeNode in="SourceGraphic"/>
+					</feMerge>
 				</filter>
 			</defs>
 			<style>
@@ -334,7 +384,7 @@ const firstEngine = engineNames[0] ?? '';
 		s += `<line x1="${ml}" y1="${mt}" x2="${ml}" y2="${mt + chartH}" stroke="#E5E7EB"/>`;
 		s += `<line x1="${ml}" y1="${mt + chartH}" x2="${ml + N * groupW}" y2="${mt + chartH}" stroke="#E5E7EB"/>`;
 
-		// Groups
+		// Groups — pass 1: dividers + X-axis labels (unclipped)
 		activeProducts.forEach((prod, gi) => {
 			const cx = groupCx(gi);
 
@@ -348,9 +398,13 @@ const firstEngine = engineNames[0] ?? '';
 			if (parts[1]) {
 				s += `<text x="${cx}" y="${ly + 15}" text-anchor="middle" fill="#6B7280" font-size="12">${parts[1]}</text>`;
 			}
+		});
 
-			models.forEach((model, bi) => {
-				const val = model[key][prod.id];
+		// Groups — pass 2: bars clipped to chart area so shadow never bleeds below X-axis
+		s += `<g clip-path="url(#chart-clip)">`;
+		activeProducts.forEach((prod, gi) => {
+			bars.forEach((bar, bi) => {
+				const val = bar[key][prod.id];
 				if (val == null) return;
 
 				const x = barLeft(gi, bi);
@@ -358,21 +412,21 @@ const firstEngine = engineNames[0] ?? '';
 				const by = mt + chartH - bh;
 				const rx = Math.min(3, barW / 5);
 
-				const gp = 5; // glow padding beyond bar edges
-				s += `<rect x="${x - gp}" y="${by - gp}" width="${barW + gp * 2}" height="${bh + gp * 2}" fill="${engineHue}" opacity="0.35" rx="${rx + 2}" filter="url(#ebar-glow)"/>`;
-				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${model.color}" rx="${rx}"
+				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${bar.color}" rx="${rx}"
 					class="bbar" filter="url(#bar-shadow)" style="cursor:pointer;animation-delay:${bi * 40}ms"
-					data-tip="${model.name}: ${val} ${benchData.unit}"/>`;
+					data-tip="${bar.label}: ${val} ${benchData.unit}"/>`;
 				if (bh > 20) {
 					s += `<text x="${x + barW / 2}" y="${by - 4}" text-anchor="middle"
-						fill="${model.isMain ? '#374151' : '#9CA3AF'}" font-size="9.5" font-weight="${model.isMain ? '600' : '400'}">${val}</text>`;
+						fill="${bar.isMain ? '#374151' : '#9CA3AF'}" font-size="9.5" font-weight="${bar.isMain ? '600' : '400'}">${val}</text>`;
 				}
 			});
 		});
+		s += `</g>`;
 
 		s += '</svg>';
 		chartEl.innerHTML = s;
 		updateBtns();
+		renderLegend();
 		attachHover();
 	}
 
@@ -404,13 +458,18 @@ const firstEngine = engineNames[0] ?? '';
 		document.getElementById('bench-btn-c1').className = conc === 'c1' ? onC : offC;
 		document.getElementById('bench-btn-c8').className = conc === 'c8' ? onC : offC;
 
-		const onE = 'px-4 py-1.5 text-xs font-semibold rounded-md bg-white text-nvidia-black shadow-sm transition-all duration-150';
+		const onE = 'px-4 py-1.5 text-xs font-semibold rounded-md bg-nvidia-black text-white shadow-sm transition-all duration-150';
 		const offE = 'px-4 py-1.5 text-xs font-semibold rounded-md text-nvidia-gray-600 hover:bg-nvidia-gray-200 transition-all duration-150';
 		document.querySelectorAll('#bench-engine-toggle [data-engine]').forEach((btn) => {
 			btn.className = btn.dataset.engine === currentEngine ? onE : offE;
+			btn.style.backgroundColor = '';
 		});
 
 		if (engineLabelEl) engineLabelEl.textContent = currentEngine;
+		const quants = Object.keys(benchData.models[0]?.engines[currentEngine] ?? {});
+		const q = quants.join(' / ');
+		if (quantLabelEl) quantLabelEl.textContent = q;
+		if (quantWrapperEl) quantWrapperEl.classList.toggle('hidden', !q);
 	}
 
 	document.getElementById('bench-btn-c1').addEventListener('click', () => { conc = 'c1'; render(); });

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -215,10 +215,10 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 	// Bar fill color per quantization tier
 	function getBarColor(quant) {
 		const q = quant.toUpperCase();
-		if (/Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]/.test(q)) return '#7C6FA0';              // GGUF quants → muted gray-purple
-		if (/FP4|INT4|W4|NF4|Q4|4.?BIT|AWQ|NVFP4|MXFP4/.test(q)) return '#A855F7'; // 4-bit → pale purple
-		if (/FP8|INT8|W8|Q8/.test(q)) return '#76B900';                               // 8-bit → NVIDIA green
-		return '#006666';                                                               // 16-bit → dark teal
+		if (/NVFP4/.test(q)) return '#A855F7';                                                          // NVFP4 → vivid purple (Blackwell tensor-core accelerated)
+		if (/FP4|INT4|W4|NF4|Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]|Q4|4.?BIT|AWQ|MXFP4/.test(q)) return '#7C6FA0'; // other 4-bit → dull gray-purple
+		if (/FP8|INT8|W8|Q8/.test(q)) return '#76B900';                                                 // 8-bit → NVIDIA green
+		return '#006666';                                                                                 // 16-bit → dark teal
 	}
 
 	// Build flat bar list: color encodes quant tier directly

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -196,6 +196,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 	let conc = 'c1';
 	let currentEngine = benchData.engineNames[0];
 	let yAxisFixed = false;
+	let showShadow = false;
 
 	const ENGINE_COLORS = {
 		'vLLM':      '#30a3ff',
@@ -413,7 +414,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 				const rx = Math.min(3, barW / 5);
 
 				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${bar.color}" rx="${rx}"
-					class="bbar" filter="url(#bar-shadow)" style="cursor:pointer;animation-delay:${bi * 40}ms"
+					class="bbar"${showShadow ? ' filter="url(#bar-shadow)"' : ''} style="cursor:pointer;animation-delay:${bi * 40}ms"
 					data-tip="${bar.label}: ${val} ${benchData.unit}"/>`;
 				if (bh > 20) {
 					s += `<text x="${x + barW / 2}" y="${by - 4}" text-anchor="middle"
@@ -476,7 +477,11 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 	document.getElementById('bench-btn-c8').addEventListener('click', () => { conc = 'c8'; render(); });
 
 	document.querySelectorAll('#bench-engine-toggle [data-engine]').forEach((btn) => {
-		btn.addEventListener('click', () => { currentEngine = btn.dataset.engine; render(); });
+		btn.addEventListener('click', (e) => {
+			if (e.ctrlKey) { showShadow = !showShadow; render(); return; }
+			currentEngine = btn.dataset.engine;
+			render();
+		});
 	});
 
 	// Lock button uses event delegation since SVG is rebuilt on each render

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -289,8 +289,8 @@ const firstEngine = engineNames[0] ?? '';
 				<filter id="ebar-glow" x="-80%" y="-80%" width="260%" height="260%">
 					<feGaussianBlur in="SourceGraphic" stdDeviation="7"/>
 				</filter>
-				<filter id="bar-shadow" x="-20%" y="-10%" width="160%" height="140%">
-					<feGaussianBlur in="SourceGraphic" stdDeviation="2.5"/>
+				<filter id="bar-shadow" x="-5%" y="-5%" width="135%" height="140%">
+					<feDropShadow dx="3" dy="4" stdDeviation="2" flood-color="black" flood-opacity="0.18"/>
 				</filter>
 			</defs>
 			<style>
@@ -360,9 +360,8 @@ const firstEngine = engineNames[0] ?? '';
 
 				const gp = 5; // glow padding beyond bar edges
 				s += `<rect x="${x - gp}" y="${by - gp}" width="${barW + gp * 2}" height="${bh + gp * 2}" fill="${engineHue}" opacity="0.35" rx="${rx + 2}" filter="url(#ebar-glow)"/>`;
-				s += `<rect x="${x + 3}" y="${by + 4}" width="${barW}" height="${bh}" fill="black" opacity="0.13" rx="${rx}" filter="url(#bar-shadow)"/>`;
 				s += `<rect x="${x}" y="${by}" width="${barW}" height="${bh}" fill="${model.color}" rx="${rx}"
-					class="bbar" style="cursor:pointer;animation-delay:${bi * 40}ms"
+					class="bbar" filter="url(#bar-shadow)" style="cursor:pointer;animation-delay:${bi * 40}ms"
 					data-tip="${model.name}: ${val} ${benchData.unit}"/>`;
 				if (bh > 20) {
 					s += `<text x="${x + barW / 2}" y="${by - 4}" text-anchor="middle"

--- a/src/components/ModelPerformanceCharts.astro
+++ b/src/components/ModelPerformanceCharts.astro
@@ -112,10 +112,22 @@ const { products, models, notes } = benchmarks;
   function render() {
     updateButtons();
 
+    function bestPerf(m: any, conc: string, prod: string): number | null {
+      if (m.performance) return m.performance[conc]?.[prod] ?? null;
+      let best: number | null = null;
+      for (const quants of Object.values(m.engines ?? {})) {
+        for (const qd of Object.values(quants as any)) {
+          const v = (qd as any)[conc]?.[prod] ?? null;
+          if (v !== null && (best === null || v > best)) best = v;
+        }
+      }
+      return best;
+    }
+
     const items = data.models
       .map((m: any) => ({
         model: m,
-        value: m.performance[concurrency][product] as number | null,
+        value: bestPerf(m, concurrency, product),
         date: parseDate(m.releaseDate),
       }))
       .filter((i: any) => i.value !== null && i.value !== undefined);

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -76,13 +76,21 @@ const modelsSchema = z.object({
 	order: z.number().optional(),
 	type: z.string().optional(),
 	/** True if the model accepts image/video (or other visual) inputs — VLM / vision-capable. */
-	vision_capable: z.boolean(),
+	vision_capable: z.boolean().optional(),
 	hf_checkpoint: z.string().optional(),
 	huggingface_url: z.string().url().optional(),
 	build_nvidia_url: z.string().url().optional(),
-	memory_requirements: z.string(),
+	memory_requirements: z.string().optional(),
 	precision: z.string(),
-	model_size: z.string(),
+	model_size: z.string().optional(),
+	/** Free-text parameter count, e.g. "~9B" or "35B total / 3B activated" */
+	parameters: z.string().optional(),
+	/** Modalities the model supports, e.g. ["Text", "Image", "Audio"] */
+	modalities: z.array(z.string()).optional(),
+	/** Maximum context window, e.g. "128K" */
+	context_length: z.string().optional(),
+	/** License name, e.g. "Apache 2.0" or "NVIDIA AI Foundations" */
+	license: z.string().optional(),
 	minimum_jetson: z.string().optional(),
 	/** Matrix tab ids to show grayed / non-clickable (e.g. not validated for this model yet). */
 	matrix_modules_disabled: z.array(z.string()).optional(),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -65,12 +65,6 @@ const servingEntrySchema = z.object({
 	run_commands_by_module: z.record(z.string()).optional(),
 });
 
-const benchmarkPlatformSchema = z.object({
-	concurrency1: z.number(),
-	concurrency8: z.number(),
-	ttftMs: z.number(),
-});
-
 const modelsSchema = z.object({
 	title: z.string(),
 	model_id: z.string().optional(),
@@ -92,6 +86,10 @@ const modelsSchema = z.object({
 	minimum_jetson: z.string().optional(),
 	/** Matrix tab ids to show grayed / non-clickable (e.g. not validated for this model yet). */
 	matrix_modules_disabled: z.array(z.string()).optional(),
+	/** Key matching the `name` field in benchmarks.json — links this model to its benchmark data. */
+	benchmark_key: z.string().optional(),
+	/** Other benchmark_key names to show as side-by-side reference bars (lineup/series comparison). */
+	benchmark_series: z.array(z.string()).optional(),
 	supported_inference_engines: z.array(supportedInferenceEngineEntrySchema).optional(),
 	serving: z
 		.object({
@@ -115,12 +113,6 @@ const modelsSchema = z.object({
 			intro: z.string().optional(),
 			shell_by_module: z.record(z.string()).optional(),
 			python_by_module: z.record(z.string()).optional(),
-		})
-		.optional(),
-	benchmark: z
-		.object({
-			orin: benchmarkPlatformSchema,
-			thor: benchmarkPlatformSchema,
 		})
 		.optional(),
 });

--- a/src/content/models/cosmos-reason1-7b.md
+++ b/src/content/models/cosmos-reason1-7b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "16GB RAM"
 precision: "FP16"
+parameters: "7B"
+modalities: ["Text", "Image", "Video"]
+context_length: "128K"
+license: "NVIDIA Open Model License"
 model_size: "14GB"
 hf_checkpoint: "nvidia/Cosmos-Reason1-7B"
 huggingface_url: "https://huggingface.co/nvidia/Cosmos-Reason1-7B"

--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "FP8"
+parameters: "2B"
+modalities: ["Text", "Image", "Video"]
+context_length: "256K"
+license: "NVIDIA Open Model License"
 model_size: "5GB"
 hf_checkpoint: "nvidia/Cosmos-Reason2-2B"
 huggingface_url: "https://huggingface.co/nvidia/Cosmos-Reason2-2B"

--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -67,6 +67,9 @@ supported_inference_engines:
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
         llama-server -hf Kbenkhaled/Cosmos-Reason2-2B-GGUF:Q8_0 -c 8192
+benchmark_key: "Cosmos Reasoning 2 2B"
+benchmark_series:
+  - "Cosmos Reasoning 2 8B"
 ---
 
 [NVIDIA Cosmos Reason 2B](https://huggingface.co/nvidia/Cosmos-Reason2-2B) is a compact vision-language model with built-in chain-of-thought reasoning capabilities. Despite its small 2B parameter size, it can perform spatial reasoning, anomaly detection, and detailed scene analysis, making it well-suited for edge deployment on Jetson.

--- a/src/content/models/cosmos-reason2-8b.md
+++ b/src/content/models/cosmos-reason2-8b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "18GB RAM"
 precision: "FP8"
+parameters: "8B"
+modalities: ["Text", "Image", "Video"]
+context_length: "256K"
+license: "NVIDIA Open Model License"
 model_size: "10GB"
 hf_checkpoint: "nvidia/Cosmos-Reason2-8B"
 huggingface_url: "https://huggingface.co/nvidia/Cosmos-Reason2-8B"

--- a/src/content/models/cosmos-reason2-8b.md
+++ b/src/content/models/cosmos-reason2-8b.md
@@ -68,6 +68,9 @@ supported_inference_engines:
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
         llama-server -hf Kbenkhaled/Cosmos-Reason2-8B-GGUF:Q4_K_M -c 8192
+benchmark_key: "Cosmos Reasoning 2 8B"
+benchmark_series:
+  - "Cosmos Reasoning 2 2B"
 ---
 
 [NVIDIA Cosmos Reason 2 8B](https://huggingface.co/nvidia/Cosmos-Reason2-8B) is the larger variant in the Cosmos Reason 2 family, offering enhanced reasoning performance with 8 billion parameters. It provides stronger chain-of-thought reasoning capabilities compared to the 2B variant, suitable for more demanding vision-language tasks on Jetson.

--- a/src/content/models/functiongemma.md
+++ b/src/content/models/functiongemma.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "1GB RAM"
 precision: "FP8"
+parameters: "270M"
+modalities: ["Text"]
+context_length: "32K"
+license: "Gemma Terms of Service"
 model_size: "0.5GB"
 hf_checkpoint: "ggml-org/functiongemma-270m-it-GGUF"
 huggingface_url: "https://huggingface.co/google/functiongemma-270m-it"

--- a/src/content/models/gemma3-12b.md
+++ b/src/content/models/gemma3-12b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "12GB RAM"
 precision: "W4A16"
+parameters: "12B"
+modalities: ["Text", "Image"]
+context_length: "128K"
+license: "Gemma Terms of Service"
 model_size: "7GB"
 hf_checkpoint: "RedHatAI/gemma-3-12b-it-quantized.w4a16"
 minimum_jetson: "Orin NX"

--- a/src/content/models/gemma3-1b.md
+++ b/src/content/models/gemma3-1b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "2GB RAM"
 precision: "FP16"
+parameters: "1B"
+modalities: ["Text"]
+context_length: "32K"
+license: "Gemma Terms of Service"
 model_size: "1.2GB"
 hf_checkpoint: "google/gemma-3-1b-it"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/gemma3-270m.md
+++ b/src/content/models/gemma3-270m.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "1GB RAM"
 precision: "FP16"
+parameters: "270M"
+modalities: ["Text"]
+context_length: "32K"
+license: "Gemma Terms of Service"
 model_size: "0.5GB"
 hf_checkpoint: "google/gemma-3-270m-it"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/gemma3-27b.md
+++ b/src/content/models/gemma3-27b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "24GB RAM"
 precision: "W4A16"
+parameters: "27B"
+modalities: ["Text", "Image"]
+context_length: "128K"
+license: "Gemma Terms of Service"
 model_size: "15GB"
 hf_checkpoint: "RedHatAI/gemma-3-27b-it-quantized.w4a16"
 huggingface_url: "https://huggingface.co/google/gemma-3-27b-it"

--- a/src/content/models/gemma3-4b.md
+++ b/src/content/models/gemma3-4b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "4GB RAM"
 precision: "W4A16"
+parameters: "4B"
+modalities: ["Text", "Image"]
+context_length: "128K"
+license: "Gemma Terms of Service"
 model_size: "2.5GB"
 hf_checkpoint: "RedHatAI/gemma-3-4b-it-quantized.w4a16"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/gemma4-26b-a4b.md
+++ b/src/content/models/gemma4-26b-a4b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "24GB RAM"
 precision: "Q4_K_M GGUF"
+parameters: "3.8B active (25.8B total, MoE)"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "16.8GB"
 hf_checkpoint: "ggml-org/gemma-4-26B-A4B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-26B-A4B-it"

--- a/src/content/models/gemma4-26b-a4b.md
+++ b/src/content/models/gemma4-26b-a4b.md
@@ -60,6 +60,10 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M
+benchmark_key: "Gemma 4 26B-A4B"
+benchmark_series:
+  - "Gemma 4 E2B"
+  - "Gemma 4 31B"
 ---
 
 Gemma 4 26B-A4B is a larger Gemma 4 variant that can be served on Jetson with `llama.cpp`. Google presents this model as the latency-optimized high-end option in the family: a Mixture-of-Experts model that targets much better throughput than a dense model of similar total size.

--- a/src/content/models/gemma4-31b.md
+++ b/src/content/models/gemma4-31b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "32GB RAM"
 precision: "Q4_K_M GGUF"
+parameters: "31B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "18.7GB"
 hf_checkpoint: "ggml-org/gemma-4-31B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-31B-it"

--- a/src/content/models/gemma4-31b.md
+++ b/src/content/models/gemma4-31b.md
@@ -60,6 +60,10 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf ggml-org/gemma-4-31B-it-GGUF:Q4_K_M
+benchmark_key: "Gemma 4 31B"
+benchmark_series:
+  - "Gemma 4 E2B"
+  - "Gemma 4 26B-A4B"
 ---
 
 Gemma 4 31B is the largest model in the current Gemma 4 set here, and it can be served on Jetson with `llama.cpp`. In Google's launch post, 31B is the flagship dense model in the family, aimed at the best possible raw quality for local reasoning, coding, and agentic workflows.

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "Q4_K_S GGUF"
+parameters: "2.3B effective (5.1B with embeddings)"
+modalities: ["Text", "Image", "Audio"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "5.0GB"
 hf_checkpoint: "ggml-org/gemma-4-E2B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-E2B-it"

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -63,6 +63,10 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf unsloth/gemma-4-E2B-it-GGUF:Q4_K_S
+benchmark_key: "Gemma 4 E2B"
+benchmark_series:
+  - "Gemma 4 26B-A4B"
+  - "Gemma 4 31B"
 ---
 
 Gemma 4 E2B is the smallest variant in the Gemma 4 family. Google positions E2B as an edge-first model for low-latency, low-memory deployments where efficiency matters more than absolute model size.

--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "Q4_K_M GGUF"
+parameters: "4.5B effective (8B with embeddings)"
+modalities: ["Text", "Image", "Audio"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "5.3GB"
 hf_checkpoint: "unsloth/gemma-4-E4B"
 huggingface_url: "https://huggingface.co/unsloth/gemma-4-E4B"

--- a/src/content/models/gpt-oss-120b.md
+++ b/src/content/models/gpt-oss-120b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "64GB RAM"
 precision: "NVFP4"
+parameters: "117B total / 5.1B activated"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "60GB"
 hf_checkpoint: "openai/gpt-oss-120b"
 huggingface_url: "https://huggingface.co/openai/gpt-oss-120b"

--- a/src/content/models/gpt-oss-20b.md
+++ b/src/content/models/gpt-oss-20b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "16GB RAM"
 precision: "W4A16"
+parameters: "21B total / 3.6B activated"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "12GB"
 hf_checkpoint: "openai/gpt-oss-20b"
 huggingface_url: "https://huggingface.co/openai/gpt-oss-20b"

--- a/src/content/models/gpt-oss-20b.md
+++ b/src/content/models/gpt-oss-20b.md
@@ -42,6 +42,7 @@ supported_inference_engines:
         -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve openai/gpt-oss-20b --gpu-memory-utilization 0.8
+benchmark_key: "GPT-OSS-20B"
 ---
 
 [OpenAI GPT OSS 20B](https://huggingface.co/openai/gpt-oss-20b) is OpenAI's open-source 20 billion parameter language model. This model requires tiktoken encodings to be downloaded before serving.

--- a/src/content/models/llama3-1-70b.md
+++ b/src/content/models/llama3-1-70b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "48GB RAM"
 precision: "W4A16"
+parameters: "70B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Llama 3.1 Community License"
 model_size: "40GB"
 hf_checkpoint: "RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16"
 huggingface_url: "https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct"

--- a/src/content/models/llama3-1-8b.md
+++ b/src/content/models/llama3-1-8b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "8GB RAM"
 precision: "W4A16"
+parameters: "8B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Llama 3.1 Community License"
 model_size: "4.5GB"
 hf_checkpoint: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
 huggingface_url: "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct"

--- a/src/content/models/llama3-2-3b.md
+++ b/src/content/models/llama3-2-3b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "4GB RAM"
 precision: "W4A16"
+parameters: "3B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Llama 3.2 Community License"
 model_size: "2.0GB"
 hf_checkpoint: "espressor/meta-llama.Llama-3.2-3B-Instruct_W4A16"
 huggingface_url: "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct"

--- a/src/content/models/ministral3-14b-instruct.md
+++ b/src/content/models/ministral3-14b-instruct.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "16GB RAM"
 precision: "FP8"
+parameters: "14B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "9GB"
 hf_checkpoint: "mistralai/Ministral-3-14B-Instruct-2512"
 minimum_jetson: "Orin AGX"

--- a/src/content/models/ministral3-14b-reasoning.md
+++ b/src/content/models/ministral3-14b-reasoning.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "16GB RAM"
 precision: "FP16"
+parameters: "14B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "9GB"
 hf_checkpoint: "mistralai/Ministral-3-14B-Reasoning-2512"
 minimum_jetson: "Orin AGX"

--- a/src/content/models/ministral3-3b-instruct.md
+++ b/src/content/models/ministral3-3b-instruct.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "4GB RAM"
 precision: "FP8"
+parameters: "3B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "2GB"
 hf_checkpoint: "mistralai/Ministral-3-3B-Instruct-2512"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/ministral3-3b-reasoning.md
+++ b/src/content/models/ministral3-3b-reasoning.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "4GB RAM"
 precision: "FP16"
+parameters: "3B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "2GB"
 hf_checkpoint: "mistralai/Ministral-3-3B-Reasoning-2512"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/ministral3-8b-instruct.md
+++ b/src/content/models/ministral3-8b-instruct.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "FP8"
+parameters: "8B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "5GB"
 hf_checkpoint: "mistralai/Ministral-3-8B-Instruct-2512"
 minimum_jetson: "Orin NX"

--- a/src/content/models/ministral3-8b-reasoning.md
+++ b/src/content/models/ministral3-8b-reasoning.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "FP16"
+parameters: "8B"
+modalities: ["Text"]
+context_length: "262K"
+license: "Apache 2.0"
 model_size: "5GB"
 hf_checkpoint: "mistralai/Ministral-3-8B-Reasoning-2512"
 minimum_jetson: "Orin NX"

--- a/src/content/models/nemotron-3-nano-30b-a3b.md
+++ b/src/content/models/nemotron-3-nano-30b-a3b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "32GB RAM"
 precision: "FP4"
+parameters: "30B total / 3B activated"
+modalities: ["Text"]
+context_length: "256K"
+license: "NVIDIA Nemotron Open Model License"
 model_size: "17GB"
 hf_checkpoint: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"
 huggingface_url: "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4"

--- a/src/content/models/nemotron-3-nano-30b-a3b.md
+++ b/src/content/models/nemotron-3-nano-30b-a3b.md
@@ -73,6 +73,10 @@ one_shot_inference:
     - orin_nano_8
   run_command_orin: ollama run nemotron-3-nano
   run_command_thor: ollama run nemotron-3-nano
+benchmark_key: "Nemotron 3 30B-A3B"
+benchmark_series:
+  - "Nemotron Nano 9B V2"
+  - "Nemotron3 Nano 4B"
 ---
 
 **Note:** The Thor command requires a [Hugging Face access token](https://huggingface.co/settings/tokens) with access to the gated NVFP4 checkpoint. The Orin command uses a community AWQ checkpoint that does not require authentication. If you see *"Free memory on device … is less than desired GPU memory utilization"*, lower `--gpu-memory-utilization` in the Advanced options.

--- a/src/content/models/nemotron-nano-12b-vl.md
+++ b/src/content/models/nemotron-nano-12b-vl.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "16GB RAM"
 precision: "NVFP4-QAD"
+parameters: "12B"
+modalities: ["Text", "Image", "Video"]
+context_length: "128K"
+license: "NVIDIA Open Model License"
 model_size: "8GB"
 hf_checkpoint: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD"
 huggingface_url: "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD"

--- a/src/content/models/nemotron-nano-9b-v2.md
+++ b/src/content/models/nemotron-nano-9b-v2.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "12GB RAM"
 precision: "NVFP4"
+parameters: "9B"
+modalities: ["Text"]
+context_length: "128K"
+license: "NVIDIA Open Model License"
 model_size: "6GB"
 hf_checkpoint: "nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4"
 huggingface_url: "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4"

--- a/src/content/models/nemotron-nano-9b-v2.md
+++ b/src/content/models/nemotron-nano-9b-v2.md
@@ -26,6 +26,10 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4
+benchmark_key: "Nemotron Nano 9B V2"
+benchmark_series:
+  - "Nemotron 3 30B-A3B"
+  - "Nemotron3 Nano 4B"
 ---
 
 NVIDIA Nemotron Nano 9B v2 is a quantized large language model trained from scratch by NVIDIA, designed as a unified model for both reasoning and non-reasoning tasks. It generates a reasoning trace before concluding with a final response, with configurable reasoning via system prompt.

--- a/src/content/models/nemotron3-nano-4b.md
+++ b/src/content/models/nemotron3-nano-4b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "4GB RAM"
 precision: "Q4_K_M GGUF"
+parameters: "4B"
+modalities: ["Text"]
+context_length: "256K"
+license: "NVIDIA Nemotron Open Model License"
 model_size: "2.5GB"
 hf_checkpoint: "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF"
 minimum_jetson: "Jetson Orin"

--- a/src/content/models/nemotron3-nano-4b.md
+++ b/src/content/models/nemotron3-nano-4b.md
@@ -45,6 +45,10 @@ supported_inference_engines:
           --ctx-size 8196 \
           --alias my_model \
           --n-gpu-layers 999
+benchmark_key: "Nemotron3 Nano 4B"
+benchmark_series:
+  - "Nemotron Nano 9B V2"
+  - "Nemotron 3 30B-A3B"
 ---
 
 Nemotron3 Nano 4B is a compact NVIDIA language model that can be served locally on Jetson with `llama.cpp`, giving Jetson Orin and Jetson Thor day-0 support through a simple OpenAI-compatible `llama-server` workflow.

--- a/src/content/models/qwen3-30b-a3b.md
+++ b/src/content/models/qwen3-30b-a3b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "16GB RAM"
 precision: "W4A16"
+parameters: "30B total / 3.3B activated"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "16GB"
 hf_checkpoint: "RedHatAI/Qwen3-30B-A3B-quantized.w4a16"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3-30B-A3B"

--- a/src/content/models/qwen3-30b-a3b.md
+++ b/src/content/models/qwen3-30b-a3b.md
@@ -41,6 +41,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve RedHatAI/Qwen3-30B-A3B-quantized.w4a16
+benchmark_key: "Qwen3-30B-A3B"
+benchmark_series:
+  - "Qwen3-32B"
 ---
 
 Qwen3 30B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3 family. It features 30 billion total parameters with only 3 billion active during inference, providing excellent performance with improved efficiency.

--- a/src/content/models/qwen3-32b.md
+++ b/src/content/models/qwen3-32b.md
@@ -40,6 +40,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve RedHatAI/Qwen3-32B-quantized.w4a16
+benchmark_key: "Qwen3-32B"
+benchmark_series:
+  - "Qwen3-30B-A3B"
 ---
 
 Qwen3 32B is the flagship dense model in Alibaba Cloud's Qwen3 family. With 32 billion parameters, it delivers exceptional performance across complex reasoning, coding, and language understanding tasks.

--- a/src/content/models/qwen3-32b.md
+++ b/src/content/models/qwen3-32b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "24GB RAM"
 precision: "W4A16"
+parameters: "32B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "18GB"
 hf_checkpoint: "RedHatAI/Qwen3-32B-quantized.w4a16"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3-32B"

--- a/src/content/models/qwen3-4b.md
+++ b/src/content/models/qwen3-4b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "4GB RAM"
 precision: "W4A16"
+parameters: "4B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "2.5GB"
 hf_checkpoint: "RedHatAI/Qwen3-4B-quantized.w4a16"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3-4B"

--- a/src/content/models/qwen3-4b.md
+++ b/src/content/models/qwen3-4b.md
@@ -43,6 +43,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve RedHatAI/Qwen3-4B-quantized.w4a16
+benchmark_key: "Qwen 3 4B"
+benchmark_series:
+  - "Qwen 3 8B"
 ---
 
 Qwen3 is Alibaba Cloud's latest generation of large language models, offering state-of-the-art performance across a wide range of tasks. The Qwen3 4B model provides an excellent balance of capability and efficiency for edge deployment.

--- a/src/content/models/qwen3-5-0-8b.md
+++ b/src/content/models/qwen3-5-0-8b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "2GB RAM"
 precision: "BF16"
+parameters: "0.8B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "1.7GB"
 hf_checkpoint: "Qwen/Qwen3.5-0.8B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-0.8B"

--- a/src/content/models/qwen3-5-27b.md
+++ b/src/content/models/qwen3-5-27b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "18GB RAM"
 precision: "NVFP4 / W4A16"
+parameters: "27B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "15GB"
 hf_checkpoint: "Qwen/Qwen3.5-27B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-27B"

--- a/src/content/models/qwen3-5-27b.md
+++ b/src/content/models/qwen3-5-27b.md
@@ -51,6 +51,9 @@ benchmark:
     concurrency1: 14
     concurrency8: 77
     ttftMs: 0
+benchmark_key: "Qwen3.5-27B"
+benchmark_series:
+  - "Qwen3.5-35B-A3B"
 ---
 
 Qwen3.5 27B is a dense language model from Alibaba Cloud's Qwen3.5 family. With 27 billion parameters, it delivers strong performance across complex reasoning, coding, and language understanding tasks.

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -51,6 +51,9 @@ benchmark:
     concurrency1: 35
     concurrency8: 125
     ttftMs: 0
+benchmark_key: "Qwen3.5-35B-A3B"
+benchmark_series:
+  - "Qwen3.5-27B"
 ---
 
 Qwen3.5 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.5 family. It features 35 billion total parameters with only 3 billion active during inference, delivering strong performance with excellent efficiency on edge devices.

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "20GB RAM"
 precision: "NVFP4 / W4A16"
+parameters: "35B total / 3B activated"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "18GB"
 hf_checkpoint: "Qwen/Qwen3.5-35B-A3B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-35B-A3B"

--- a/src/content/models/qwen3-5-4b.md
+++ b/src/content/models/qwen3-5-4b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "4GB RAM"
 precision: "AWQ 4-bit"
+parameters: "4B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "2.5GB"
 hf_checkpoint: "cyankiwi/Qwen3.5-4B-AWQ-4bit"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-4B"

--- a/src/content/models/qwen3-5-9b.md
+++ b/src/content/models/qwen3-5-9b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "NVFP4 / W4A16"
+parameters: "9B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "5GB"
 hf_checkpoint: "Qwen/Qwen3.5-9B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-9B"

--- a/src/content/models/qwen3-8b.md
+++ b/src/content/models/qwen3-8b.md
@@ -10,6 +10,10 @@ type: "Text"
 vision_capable: false
 memory_requirements: "8GB RAM"
 precision: "W4A16"
+parameters: "8B"
+modalities: ["Text"]
+context_length: "128K"
+license: "Apache 2.0"
 model_size: "4.5GB"
 hf_checkpoint: "RedHatAI/Qwen3-8B-quantized.w4a16"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3-8B"

--- a/src/content/models/qwen3-8b.md
+++ b/src/content/models/qwen3-8b.md
@@ -42,6 +42,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve RedHatAI/Qwen3-8B-quantized.w4a16
+benchmark_key: "Qwen 3 8B"
+benchmark_series:
+  - "Qwen 3 4B"
 ---
 
 Qwen3 8B is a more powerful variant in Alibaba Cloud's latest generation of large language models. With 8 billion parameters, it offers enhanced capabilities while remaining deployable on edge devices.

--- a/src/content/models/qwen3-vl-4b.md
+++ b/src/content/models/qwen3-vl-4b.md
@@ -33,6 +33,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit
+benchmark_key: "Qwen3-VL-4B"
+benchmark_series:
+  - "Qwen3-VL-8B"
 ---
 
 Meet Qwen3-VL — the most powerful vision-language model in the Qwen series to date.

--- a/src/content/models/qwen3-vl-4b.md
+++ b/src/content/models/qwen3-vl-4b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "6GB RAM"
 precision: "AWQ 4-bit"
+parameters: "4B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "3GB"
 hf_checkpoint: "cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit"
 minimum_jetson: "Orin Nano"

--- a/src/content/models/qwen3-vl-8b.md
+++ b/src/content/models/qwen3-vl-8b.md
@@ -32,6 +32,9 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
         vllm serve cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit
+benchmark_key: "Qwen3-VL-8B"
+benchmark_series:
+  - "Qwen3-VL-4B"
 ---
 
 Meet Qwen3-VL — the most powerful vision-language model in the Qwen series to date.

--- a/src/content/models/qwen3-vl-8b.md
+++ b/src/content/models/qwen3-vl-8b.md
@@ -10,6 +10,10 @@ type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
 precision: "AWQ 4-bit"
+parameters: "8B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
 model_size: "5GB"
 hf_checkpoint: "cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit"
 minimum_jetson: "Orin NX"

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -16,12 +16,13 @@
       "releaseDate": "2025-08-18",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 30, "t4000": 24, "agx_orin_64gb": 20, "orin_nx_16gb": 11, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 100, "t4000": 82, "agx_orin_64gb": 85, "orin_nx_16gb": 60, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 30, "t4000": 24, "agx_orin_64gb": 20, "orin_nx_16gb": 11, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 100, "t4000": 82, "agx_orin_64gb": 85, "orin_nx_16gb": 60, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -30,12 +31,13 @@
       "releaseDate": "2025-12-15",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 55, "t4000": 46, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 161, "t4000": 135, "agx_orin_64gb": 71, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 55, "t4000": 46, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 161, "t4000": 135, "agx_orin_64gb": 71, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -44,12 +46,13 @@
       "releaseDate": "2026-03-16",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "Q4_K_M GGUF",
-      "framework": "llama.cpp",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 56, "t4000": null, "agx_orin_64gb": 43, "orin_nx_16gb": 22, "orin_nano_8gb": 18 },
-        "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "llama.cpp": {
+          "concurrency1": { "t5000": 56, "t4000": null, "agx_orin_64gb": 43, "orin_nx_16gb": 22, "orin_nano_8gb": 18 },
+          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -58,12 +61,13 @@
       "releaseDate": "2025-12-19",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "quantization": "NVFP4*",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 108, "t4000": 89, "agx_orin_64gb": 59, "orin_nx_16gb": 25, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 482, "t4000": 410, "agx_orin_64gb": 273, "orin_nx_16gb": 65, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 108, "t4000": 89, "agx_orin_64gb": 59, "orin_nx_16gb": 25, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 482, "t4000": 410, "agx_orin_64gb": 273, "orin_nx_16gb": 65, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -72,12 +76,13 @@
       "releaseDate": "2025-12-19",
       "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "quantization": "NVFP4*",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 40, "t4000": 32, "agx_orin_64gb": 19, "orin_nx_16gb": 6, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 222, "t4000": 190, "agx_orin_64gb": 108, "orin_nx_16gb": 12, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 40, "t4000": 32, "agx_orin_64gb": 19, "orin_nx_16gb": 6, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 222, "t4000": 190, "agx_orin_64gb": 108, "orin_nx_16gb": 12, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -86,12 +91,13 @@
       "releaseDate": "2025-04-28",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 68, "t4000": 55, "agx_orin_64gb": 50, "orin_nx_16gb": 17, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 311, "t4000": 258, "agx_orin_64gb": 222, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 68, "t4000": 55, "agx_orin_64gb": 50, "orin_nx_16gb": 17, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 311, "t4000": 258, "agx_orin_64gb": 222, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -100,12 +106,13 @@
       "releaseDate": "2025-04-28",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 41, "t4000": 35, "agx_orin_64gb": 30, "orin_nx_16gb": 9, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 241, "t4000": 200, "agx_orin_64gb": 157, "orin_nx_16gb": 22, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 41, "t4000": 35, "agx_orin_64gb": 30, "orin_nx_16gb": 9, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 241, "t4000": 200, "agx_orin_64gb": 157, "orin_nx_16gb": 22, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -114,12 +121,13 @@
       "releaseDate": "2025-04-28",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 67, "t4000": 57, "agx_orin_64gb": 55, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 242, "t4000": 184, "agx_orin_64gb": 174, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 67, "t4000": 57, "agx_orin_64gb": 55, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 242, "t4000": 184, "agx_orin_64gb": 174, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -128,12 +136,13 @@
       "releaseDate": "2025-04-28",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 12, "t4000": 12, "agx_orin_64gb": 7, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 77, "t4000": 63, "agx_orin_64gb": 17, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 12, "t4000": 12, "agx_orin_64gb": 7, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 77, "t4000": 63, "agx_orin_64gb": 17, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -142,12 +151,13 @@
       "releaseDate": "2026-02-27",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 35, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 125, "t4000": null, "agx_orin_64gb": 80, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 35, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 125, "t4000": null, "agx_orin_64gb": 80, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -156,12 +166,13 @@
       "releaseDate": "2026-02-27",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 14, "t4000": null, "agx_orin_64gb": 9, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 77, "t4000": null, "agx_orin_64gb": 41, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 14, "t4000": null, "agx_orin_64gb": 9, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 77, "t4000": null, "agx_orin_64gb": 41, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -170,12 +181,13 @@
       "releaseDate": "2025-10-21",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 122, "t4000": 95, "agx_orin_64gb": 60, "orin_nx_16gb": 21, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 500, "t4000": 423, "agx_orin_64gb": 91, "orin_nx_16gb": 28, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 122, "t4000": 95, "agx_orin_64gb": 60, "orin_nx_16gb": 21, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 500, "t4000": 423, "agx_orin_64gb": 91, "orin_nx_16gb": 28, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -184,12 +196,13 @@
       "releaseDate": "2025-10-15",
       "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "quantization": "w4a16",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 69, "t4000": 53, "agx_orin_64gb": 47, "orin_nx_16gb": 16, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 318, "t4000": 257, "agx_orin_64gb": 214, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 69, "t4000": 53, "agx_orin_64gb": 47, "orin_nx_16gb": 16, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 318, "t4000": 257, "agx_orin_64gb": 214, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -198,12 +211,13 @@
       "releaseDate": "2025-10-15",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 41, "t4000": 33, "agx_orin_64gb": 28, "orin_nx_16gb": 9, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 224, "t4000": 177, "agx_orin_64gb": 149, "orin_nx_16gb": 20, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 41, "t4000": 33, "agx_orin_64gb": 28, "orin_nx_16gb": 9, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 224, "t4000": 177, "agx_orin_64gb": 149, "orin_nx_16gb": 20, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -212,12 +226,13 @@
       "releaseDate": "2025-09-22",
       "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "quantization": "NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -226,12 +241,13 @@
       "releaseDate": "2026-04-02",
       "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "quantization": "Q8_0",
-      "framework": "llama.cpp",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "llama.cpp": {
+          "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -240,12 +256,13 @@
       "releaseDate": "2026-04-02",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "quantization": "AWQ-4bit / NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 50, "t4000": null, "agx_orin_64gb": 32, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 180, "t4000": null, "agx_orin_64gb": 110, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 50, "t4000": null, "agx_orin_64gb": 32, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 180, "t4000": null, "agx_orin_64gb": 110, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -254,12 +271,13 @@
       "releaseDate": "2026-04-02",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "quantization": "AWQ-4bit / NVFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 7, "t4000": null, "agx_orin_64gb": 5, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 43, "t4000": null, "agx_orin_64gb": 15, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 7, "t4000": null, "agx_orin_64gb": 5, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 43, "t4000": null, "agx_orin_64gb": 15, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -268,12 +286,13 @@
       "releaseDate": "2025-08-05",
       "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "quantization": "MXFP4",
-      "framework": "VLLM",
       "isl": 2048,
       "osl": 128,
-      "performance": {
-        "concurrency1": { "t5000": 59, "t4000": 42, "agx_orin_64gb": 39, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 215, "t4000": 160, "agx_orin_64gb": 147, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "vLLM": {
+          "concurrency1": { "t5000": 59, "t4000": 42, "agx_orin_64gb": 39, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": 215, "t4000": 160, "agx_orin_64gb": 147, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     },
     {
@@ -282,12 +301,13 @@
       "releaseDate": "2025-04-22",
       "capabilities": { "language": false, "vision": false, "audio": false, "vla": true },
       "quantization": "NVFP4 + FP8",
-      "framework": "TRT",
       "isl": null,
       "osl": null,
-      "performance": {
-        "concurrency1": { "t5000": 117, "t4000": 94, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      "engines": {
+        "TRT": {
+          "concurrency1": { "t5000": 117, "t4000": 94, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        }
       }
     }
   ]

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -32,38 +32,26 @@
     }
   ],
   "notes": [
-    "Unless otherwise specified, all models utilize W4A16 quantization for Orin and NVFP4 for Thor."
+    "Unless otherwise specified, all models utilize W4A16 quantization for Orin and NVFP4 for Thor.",
+    "NVFP4 and MXFP4 require Blackwell FP4 tensor cores and are not available on Orin (Ampere)."
   ],
   "models": [
     {
       "family": "Nemotron",
       "name": "Nemotron Nano 9B V2",
       "releaseDate": "2025-08-18",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 30,
-              "t4000": 24,
-              "agx_orin_64gb": 20,
-              "orin_nx_16gb": 11,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 100,
-              "t4000": 82,
-              "agx_orin_64gb": 85,
-              "orin_nx_16gb": 60,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 30, "t4000": 24, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 100, "t4000": 82, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 20, "orin_nx_16gb": 11, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 85, "orin_nx_16gb": 60, "orin_nano_8gb": null }
           }
         }
       }
@@ -72,31 +60,18 @@
       "family": "Nemotron",
       "name": "Nemotron 3 30B-A3B",
       "releaseDate": "2025-12-15",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 55,
-              "t4000": 46,
-              "agx_orin_64gb": 35,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 161,
-              "t4000": 135,
-              "agx_orin_64gb": 71,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 55, "t4000": 46, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 161, "t4000": 135, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 71, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -105,31 +80,14 @@
       "family": "Nemotron",
       "name": "Nemotron3 Nano 4B",
       "releaseDate": "2026-03-16",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "llama.cpp": {
           "Q4_K_M GGUF": {
-            "concurrency1": {
-              "t5000": 56,
-              "t4000": null,
-              "agx_orin_64gb": 43,
-              "orin_nx_16gb": 22,
-              "orin_nano_8gb": 18
-            },
-            "concurrency8": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 56, "t4000": null, "agx_orin_64gb": 43, "orin_nx_16gb": 22, "orin_nano_8gb": 18 },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -138,31 +96,18 @@
       "family": "Cosmos Reasoning",
       "name": "Cosmos Reasoning 2 2B",
       "releaseDate": "2025-12-19",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4*": {
-            "concurrency1": {
-              "t5000": 108,
-              "t4000": 89,
-              "agx_orin_64gb": 59,
-              "orin_nx_16gb": 25,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 482,
-              "t4000": 410,
-              "agx_orin_64gb": 273,
-              "orin_nx_16gb": 65,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 108, "t4000": 89, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 482, "t4000": 410, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 59, "orin_nx_16gb": 25, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 273, "orin_nx_16gb": 65, "orin_nano_8gb": null }
           }
         }
       }
@@ -171,31 +116,18 @@
       "family": "Cosmos Reasoning",
       "name": "Cosmos Reasoning 2 8B",
       "releaseDate": "2025-12-19",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": true,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4*": {
-            "concurrency1": {
-              "t5000": 40,
-              "t4000": 32,
-              "agx_orin_64gb": 19,
-              "orin_nx_16gb": 6,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 222,
-              "t4000": 190,
-              "agx_orin_64gb": 108,
-              "orin_nx_16gb": 12,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 40, "t4000": 32, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 222, "t4000": 190, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 19, "orin_nx_16gb": 6, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 108, "orin_nx_16gb": 12, "orin_nano_8gb": null }
           }
         }
       }
@@ -204,31 +136,18 @@
       "family": "Qwen",
       "name": "Qwen 3 4B",
       "releaseDate": "2025-04-28",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 68,
-              "t4000": 55,
-              "agx_orin_64gb": 50,
-              "orin_nx_16gb": 17,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 311,
-              "t4000": 258,
-              "agx_orin_64gb": 222,
-              "orin_nx_16gb": 35,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 68, "t4000": 55, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 311, "t4000": 258, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 50, "orin_nx_16gb": 17, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 222, "orin_nx_16gb": 35, "orin_nano_8gb": null }
           }
         }
       }
@@ -237,31 +156,18 @@
       "family": "Qwen",
       "name": "Qwen 3 8B",
       "releaseDate": "2025-04-28",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 41,
-              "t4000": 35,
-              "agx_orin_64gb": 30,
-              "orin_nx_16gb": 9,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 241,
-              "t4000": 200,
-              "agx_orin_64gb": 157,
-              "orin_nx_16gb": 22,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 41, "t4000": 35, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 241, "t4000": 200, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": 9, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 157, "orin_nx_16gb": 22, "orin_nano_8gb": null }
           }
         }
       }
@@ -270,31 +176,18 @@
       "family": "Qwen",
       "name": "Qwen3-30B-A3B",
       "releaseDate": "2025-04-28",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 67,
-              "t4000": 57,
-              "agx_orin_64gb": 55,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 242,
-              "t4000": 184,
-              "agx_orin_64gb": 174,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 67, "t4000": 57, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 242, "t4000": 184, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 55, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 174, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -303,31 +196,18 @@
       "family": "Qwen",
       "name": "Qwen3-32B",
       "releaseDate": "2025-04-28",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 12,
-              "t4000": 12,
-              "agx_orin_64gb": 7,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 77,
-              "t4000": 63,
-              "agx_orin_64gb": 17,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 12, "t4000": 12, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 77, "t4000": 63, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 7, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 17, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -336,31 +216,18 @@
       "family": "Qwen",
       "name": "Qwen3.5-35B-A3B",
       "releaseDate": "2026-02-27",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 35,
-              "t4000": null,
-              "agx_orin_64gb": 30,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 125,
-              "t4000": null,
-              "agx_orin_64gb": 80,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 35, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 125, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 80, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -369,31 +236,18 @@
       "family": "Qwen",
       "name": "Qwen3.5-27B",
       "releaseDate": "2026-02-27",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 14,
-              "t4000": null,
-              "agx_orin_64gb": 9,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 77,
-              "t4000": null,
-              "agx_orin_64gb": 41,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 14, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 77, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 9, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 41, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -402,31 +256,18 @@
       "family": "Qwen",
       "name": "Qwen3-VL-2B",
       "releaseDate": "2025-10-21",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 122,
-              "t4000": 95,
-              "agx_orin_64gb": 60,
-              "orin_nx_16gb": 21,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 500,
-              "t4000": 423,
-              "agx_orin_64gb": 91,
-              "orin_nx_16gb": 28,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 122, "t4000": 95, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 500, "t4000": 423, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 60, "orin_nx_16gb": 21, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 91, "orin_nx_16gb": 28, "orin_nano_8gb": null }
           }
         }
       }
@@ -435,31 +276,14 @@
       "family": "Qwen",
       "name": "Qwen3-VL-4B",
       "releaseDate": "2025-10-15",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": true,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "w4a16": {
-            "concurrency1": {
-              "t5000": 69,
-              "t4000": 53,
-              "agx_orin_64gb": 47,
-              "orin_nx_16gb": 16,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 318,
-              "t4000": 257,
-              "agx_orin_64gb": 214,
-              "orin_nx_16gb": 35,
-              "orin_nano_8gb": null
-            }
+          "W4A16": {
+            "concurrency1": { "t5000": 69, "t4000": 53, "agx_orin_64gb": 47, "orin_nx_16gb": 16, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 318, "t4000": 257, "agx_orin_64gb": 214, "orin_nx_16gb": 35, "orin_nano_8gb": null }
           }
         }
       }
@@ -468,31 +292,18 @@
       "family": "Qwen",
       "name": "Qwen3-VL-8B",
       "releaseDate": "2025-10-15",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": 41,
-              "t4000": 33,
-              "agx_orin_64gb": 28,
-              "orin_nx_16gb": 9,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 224,
-              "t4000": 177,
-              "agx_orin_64gb": 149,
-              "orin_nx_16gb": 20,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 41, "t4000": 33, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 224, "t4000": 177, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 28, "orin_nx_16gb": 9, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 149, "orin_nx_16gb": 20, "orin_nano_8gb": null }
           }
         }
       }
@@ -501,31 +312,14 @@
       "family": "Qwen",
       "name": "Qwen3-Omni-30B-A3B",
       "releaseDate": "2025-09-22",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": true,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "NVFP4": {
-            "concurrency1": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -534,31 +328,14 @@
       "family": "Gemma",
       "name": "Gemma 4 E2B",
       "releaseDate": "2026-04-02",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": true,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "llama.cpp": {
           "Q8_0": {
-            "concurrency1": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": 35,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -567,31 +344,18 @@
       "family": "Gemma",
       "name": "Gemma 4 26B-A4B",
       "releaseDate": "2026-04-02",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "AWQ-4bit / NVFP4": {
-            "concurrency1": {
-              "t5000": 50,
-              "t4000": null,
-              "agx_orin_64gb": 32,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 180,
-              "t4000": null,
-              "agx_orin_64gb": 110,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+          "NVFP4": {
+            "concurrency1": { "t5000": 50, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 180, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "AWQ": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 32, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 110, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -600,31 +364,18 @@
       "family": "Gemma",
       "name": "Gemma 4 31B",
       "releaseDate": "2026-04-02",
-      "capabilities": {
-        "language": true,
-        "vision": true,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "AWQ-4bit / NVFP4": {
-            "concurrency1": {
-              "t5000": 7,
-              "t4000": null,
-              "agx_orin_64gb": 5,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 43,
-              "t4000": null,
-              "agx_orin_64gb": 15,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+          "NVFP4": {
+            "concurrency1": { "t5000": 7, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 43, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "AWQ": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 5, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 15, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -633,31 +384,18 @@
       "family": "GPT OSS",
       "name": "GPT-OSS-20B",
       "releaseDate": "2025-08-05",
-      "capabilities": {
-        "language": true,
-        "vision": false,
-        "audio": false,
-        "vla": false
-      },
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
           "MXFP4": {
-            "concurrency1": {
-              "t5000": 59,
-              "t4000": 42,
-              "agx_orin_64gb": 39,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": 215,
-              "t4000": 160,
-              "agx_orin_64gb": 147,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 59, "t4000": 42, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": 215, "t4000": 160, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          },
+          "W4A16": {
+            "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 39, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": 147, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }
@@ -666,31 +404,14 @@
       "family": "Pi",
       "name": "Pi 0.5",
       "releaseDate": "2025-04-22",
-      "capabilities": {
-        "language": false,
-        "vision": false,
-        "audio": false,
-        "vla": true
-      },
+      "capabilities": { "language": false, "vision": false, "audio": false, "vla": true },
       "isl": null,
       "osl": null,
       "engines": {
         "TRT": {
           "NVFP4 + FP8": {
-            "concurrency1": {
-              "t5000": 117,
-              "t4000": 94,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            },
-            "concurrency8": {
-              "t5000": null,
-              "t4000": null,
-              "agx_orin_64gb": null,
-              "orin_nx_16gb": null,
-              "orin_nano_8gb": null
-            }
+            "concurrency1": { "t5000": 117, "t4000": 94, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+            "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
           }
         }
       }

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -1,10 +1,35 @@
 {
   "products": [
-    { "id": "t5000", "name": "T5000", "fullName": "Jetson Thor T5000", "generation": "Thor" },
-    { "id": "t4000", "name": "T4000", "fullName": "Jetson Thor T4000", "generation": "Thor" },
-    { "id": "agx_orin_64gb", "name": "AGX Orin 64GB", "fullName": "Jetson AGX Orin 64GB", "generation": "Orin" },
-    { "id": "orin_nx_16gb", "name": "Orin NX 16GB", "fullName": "Jetson Orin NX 16GB", "generation": "Orin" },
-    { "id": "orin_nano_8gb", "name": "Orin Nano 8GB", "fullName": "Jetson Orin Nano 8GB", "generation": "Orin" }
+    {
+      "id": "t5000",
+      "name": "T5000",
+      "fullName": "Jetson Thor T5000",
+      "generation": "Thor"
+    },
+    {
+      "id": "t4000",
+      "name": "T4000",
+      "fullName": "Jetson Thor T4000",
+      "generation": "Thor"
+    },
+    {
+      "id": "agx_orin_64gb",
+      "name": "AGX Orin 64GB",
+      "fullName": "Jetson AGX Orin 64GB",
+      "generation": "Orin"
+    },
+    {
+      "id": "orin_nx_16gb",
+      "name": "Orin NX 16GB",
+      "fullName": "Jetson Orin NX 16GB",
+      "generation": "Orin"
+    },
+    {
+      "id": "orin_nano_8gb",
+      "name": "Orin Nano 8GB",
+      "fullName": "Jetson Orin Nano 8GB",
+      "generation": "Orin"
+    }
   ],
   "notes": [
     "Unless otherwise specified, all models utilize W4A16 quantization for Orin and NVFP4 for Thor."
@@ -14,14 +39,32 @@
       "family": "Nemotron",
       "name": "Nemotron Nano 9B V2",
       "releaseDate": "2025-08-18",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 30, "t4000": 24, "agx_orin_64gb": 20, "orin_nx_16gb": 11, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 100, "t4000": 82, "agx_orin_64gb": 85, "orin_nx_16gb": 60, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 30,
+              "t4000": 24,
+              "agx_orin_64gb": 20,
+              "orin_nx_16gb": 11,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 100,
+              "t4000": 82,
+              "agx_orin_64gb": 85,
+              "orin_nx_16gb": 60,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -29,14 +72,32 @@
       "family": "Nemotron",
       "name": "Nemotron 3 30B-A3B",
       "releaseDate": "2025-12-15",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 55, "t4000": 46, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 161, "t4000": 135, "agx_orin_64gb": 71, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 55,
+              "t4000": 46,
+              "agx_orin_64gb": 35,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 161,
+              "t4000": 135,
+              "agx_orin_64gb": 71,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -44,14 +105,32 @@
       "family": "Nemotron",
       "name": "Nemotron3 Nano 4B",
       "releaseDate": "2026-03-16",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "Q4_K_M GGUF",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "llama.cpp": {
-          "concurrency1": { "t5000": 56, "t4000": null, "agx_orin_64gb": 43, "orin_nx_16gb": 22, "orin_nano_8gb": 18 },
-          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "Q4_K_M GGUF": {
+            "concurrency1": {
+              "t5000": 56,
+              "t4000": null,
+              "agx_orin_64gb": 43,
+              "orin_nx_16gb": 22,
+              "orin_nano_8gb": 18
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -59,14 +138,32 @@
       "family": "Cosmos Reasoning",
       "name": "Cosmos Reasoning 2 2B",
       "releaseDate": "2025-12-19",
-      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
-      "quantization": "NVFP4*",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 108, "t4000": 89, "agx_orin_64gb": 59, "orin_nx_16gb": 25, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 482, "t4000": 410, "agx_orin_64gb": 273, "orin_nx_16gb": 65, "orin_nano_8gb": null }
+          "NVFP4*": {
+            "concurrency1": {
+              "t5000": 108,
+              "t4000": 89,
+              "agx_orin_64gb": 59,
+              "orin_nx_16gb": 25,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 482,
+              "t4000": 410,
+              "agx_orin_64gb": 273,
+              "orin_nx_16gb": 65,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -74,14 +171,32 @@
       "family": "Cosmos Reasoning",
       "name": "Cosmos Reasoning 2 8B",
       "releaseDate": "2025-12-19",
-      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
-      "quantization": "NVFP4*",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": true,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 40, "t4000": 32, "agx_orin_64gb": 19, "orin_nx_16gb": 6, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 222, "t4000": 190, "agx_orin_64gb": 108, "orin_nx_16gb": 12, "orin_nano_8gb": null }
+          "NVFP4*": {
+            "concurrency1": {
+              "t5000": 40,
+              "t4000": 32,
+              "agx_orin_64gb": 19,
+              "orin_nx_16gb": 6,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 222,
+              "t4000": 190,
+              "agx_orin_64gb": 108,
+              "orin_nx_16gb": 12,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -89,14 +204,32 @@
       "family": "Qwen",
       "name": "Qwen 3 4B",
       "releaseDate": "2025-04-28",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 68, "t4000": 55, "agx_orin_64gb": 50, "orin_nx_16gb": 17, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 311, "t4000": 258, "agx_orin_64gb": 222, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 68,
+              "t4000": 55,
+              "agx_orin_64gb": 50,
+              "orin_nx_16gb": 17,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 311,
+              "t4000": 258,
+              "agx_orin_64gb": 222,
+              "orin_nx_16gb": 35,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -104,14 +237,32 @@
       "family": "Qwen",
       "name": "Qwen 3 8B",
       "releaseDate": "2025-04-28",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 41, "t4000": 35, "agx_orin_64gb": 30, "orin_nx_16gb": 9, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 241, "t4000": 200, "agx_orin_64gb": 157, "orin_nx_16gb": 22, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 41,
+              "t4000": 35,
+              "agx_orin_64gb": 30,
+              "orin_nx_16gb": 9,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 241,
+              "t4000": 200,
+              "agx_orin_64gb": 157,
+              "orin_nx_16gb": 22,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -119,14 +270,32 @@
       "family": "Qwen",
       "name": "Qwen3-30B-A3B",
       "releaseDate": "2025-04-28",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 67, "t4000": 57, "agx_orin_64gb": 55, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 242, "t4000": 184, "agx_orin_64gb": 174, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 67,
+              "t4000": 57,
+              "agx_orin_64gb": 55,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 242,
+              "t4000": 184,
+              "agx_orin_64gb": 174,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -134,14 +303,32 @@
       "family": "Qwen",
       "name": "Qwen3-32B",
       "releaseDate": "2025-04-28",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 12, "t4000": 12, "agx_orin_64gb": 7, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 77, "t4000": 63, "agx_orin_64gb": 17, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 12,
+              "t4000": 12,
+              "agx_orin_64gb": 7,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 77,
+              "t4000": 63,
+              "agx_orin_64gb": 17,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -149,14 +336,32 @@
       "family": "Qwen",
       "name": "Qwen3.5-35B-A3B",
       "releaseDate": "2026-02-27",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 35, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 125, "t4000": null, "agx_orin_64gb": 80, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 35,
+              "t4000": null,
+              "agx_orin_64gb": 30,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 125,
+              "t4000": null,
+              "agx_orin_64gb": 80,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -164,14 +369,32 @@
       "family": "Qwen",
       "name": "Qwen3.5-27B",
       "releaseDate": "2026-02-27",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 14, "t4000": null, "agx_orin_64gb": 9, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 77, "t4000": null, "agx_orin_64gb": 41, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 14,
+              "t4000": null,
+              "agx_orin_64gb": 9,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 77,
+              "t4000": null,
+              "agx_orin_64gb": 41,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -179,14 +402,32 @@
       "family": "Qwen",
       "name": "Qwen3-VL-2B",
       "releaseDate": "2025-10-21",
-      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 122, "t4000": 95, "agx_orin_64gb": 60, "orin_nx_16gb": 21, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 500, "t4000": 423, "agx_orin_64gb": 91, "orin_nx_16gb": 28, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 122,
+              "t4000": 95,
+              "agx_orin_64gb": 60,
+              "orin_nx_16gb": 21,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 500,
+              "t4000": 423,
+              "agx_orin_64gb": 91,
+              "orin_nx_16gb": 28,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -194,14 +435,32 @@
       "family": "Qwen",
       "name": "Qwen3-VL-4B",
       "releaseDate": "2025-10-15",
-      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
-      "quantization": "w4a16",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": true,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 69, "t4000": 53, "agx_orin_64gb": 47, "orin_nx_16gb": 16, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 318, "t4000": 257, "agx_orin_64gb": 214, "orin_nx_16gb": 35, "orin_nano_8gb": null }
+          "w4a16": {
+            "concurrency1": {
+              "t5000": 69,
+              "t4000": 53,
+              "agx_orin_64gb": 47,
+              "orin_nx_16gb": 16,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 318,
+              "t4000": 257,
+              "agx_orin_64gb": 214,
+              "orin_nx_16gb": 35,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -209,14 +468,32 @@
       "family": "Qwen",
       "name": "Qwen3-VL-8B",
       "releaseDate": "2025-10-15",
-      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 41, "t4000": 33, "agx_orin_64gb": 28, "orin_nx_16gb": 9, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 224, "t4000": 177, "agx_orin_64gb": 149, "orin_nx_16gb": 20, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 41,
+              "t4000": 33,
+              "agx_orin_64gb": 28,
+              "orin_nx_16gb": 9,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 224,
+              "t4000": 177,
+              "agx_orin_64gb": 149,
+              "orin_nx_16gb": 20,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -224,14 +501,32 @@
       "family": "Qwen",
       "name": "Qwen3-Omni-30B-A3B",
       "releaseDate": "2025-09-22",
-      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
-      "quantization": "NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": true,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -239,14 +534,32 @@
       "family": "Gemma",
       "name": "Gemma 4 E2B",
       "releaseDate": "2026-04-02",
-      "capabilities": { "language": true, "vision": true, "audio": true, "vla": false },
-      "quantization": "Q8_0",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": true,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "llama.cpp": {
-          "concurrency1": { "t5000": null, "t4000": null, "agx_orin_64gb": 35, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "Q8_0": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 35,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -254,14 +567,32 @@
       "family": "Gemma",
       "name": "Gemma 4 26B-A4B",
       "releaseDate": "2026-04-02",
-      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
-      "quantization": "AWQ-4bit / NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 50, "t4000": null, "agx_orin_64gb": 32, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 180, "t4000": null, "agx_orin_64gb": 110, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "AWQ-4bit / NVFP4": {
+            "concurrency1": {
+              "t5000": 50,
+              "t4000": null,
+              "agx_orin_64gb": 32,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 180,
+              "t4000": null,
+              "agx_orin_64gb": 110,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -269,14 +600,32 @@
       "family": "Gemma",
       "name": "Gemma 4 31B",
       "releaseDate": "2026-04-02",
-      "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },
-      "quantization": "AWQ-4bit / NVFP4",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 7, "t4000": null, "agx_orin_64gb": 5, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 43, "t4000": null, "agx_orin_64gb": 15, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "AWQ-4bit / NVFP4": {
+            "concurrency1": {
+              "t5000": 7,
+              "t4000": null,
+              "agx_orin_64gb": 5,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 43,
+              "t4000": null,
+              "agx_orin_64gb": 15,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -284,14 +633,32 @@
       "family": "GPT OSS",
       "name": "GPT-OSS-20B",
       "releaseDate": "2025-08-05",
-      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
-      "quantization": "MXFP4",
+      "capabilities": {
+        "language": true,
+        "vision": false,
+        "audio": false,
+        "vla": false
+      },
       "isl": 2048,
       "osl": 128,
       "engines": {
         "vLLM": {
-          "concurrency1": { "t5000": 59, "t4000": 42, "agx_orin_64gb": 39, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": 215, "t4000": 160, "agx_orin_64gb": 147, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "MXFP4": {
+            "concurrency1": {
+              "t5000": 59,
+              "t4000": 42,
+              "agx_orin_64gb": 39,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": 215,
+              "t4000": 160,
+              "agx_orin_64gb": 147,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     },
@@ -299,14 +666,32 @@
       "family": "Pi",
       "name": "Pi 0.5",
       "releaseDate": "2025-04-22",
-      "capabilities": { "language": false, "vision": false, "audio": false, "vla": true },
-      "quantization": "NVFP4 + FP8",
+      "capabilities": {
+        "language": false,
+        "vision": false,
+        "audio": false,
+        "vla": true
+      },
       "isl": null,
       "osl": null,
       "engines": {
         "TRT": {
-          "concurrency1": { "t5000": 117, "t4000": 94, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
-          "concurrency8": { "t5000": null, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+          "NVFP4 + FP8": {
+            "concurrency1": {
+              "t5000": 117,
+              "t4000": 94,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null
+            }
+          }
         }
       }
     }

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -6,6 +6,7 @@ import ModelCallSection from '../../components/ModelCallSection.astro';
 import ModelBenchmarkSection from '../../components/ModelBenchmarkSection.astro';
 import ModelOneShotSection from '../../components/ModelOneShotSection.astro';
 import { getSupportedInferenceEngines, sortEnginesForUi } from '../../lib/modelFrontmatterAdapter';
+import benchmarksData from '../../data/benchmarks.json';
 
 export async function getStaticPaths() {
   const models = await getCollection('models');
@@ -24,6 +25,14 @@ const huggingfaceUrl = data.huggingface_url || (data.hf_checkpoint ? `https://hu
 const isGemma4Family = data.family === 'Google Gemma4';
 
 const sortedEngines = sortEnginesForUi(getSupportedInferenceEngines(data));
+
+const benchmarkEntry = data.benchmark_key
+  ? ((benchmarksData.models as any[]).find((m) => m.name === data.benchmark_key) ?? null)
+  : null;
+
+const benchmarkSeries = (data.benchmark_series ?? [])
+  .map((k) => (benchmarksData.models as any[]).find((m) => m.name === k) ?? null)
+  .filter((m): m is NonNullable<typeof m> => m !== null);
 
 const inferenceNeedsHfToken = sortedEngines.some((e) => {
   const cmds = [
@@ -126,10 +135,11 @@ const inferenceNeedsHfToken = sortedEngines.some((e) => {
         </div>
       </section>
       <ModelOneShotSection oneShot={data.one_shot_inference} modelSlug={entry.slug} />
-      {data.benchmark && (
-        <ModelBenchmarkSection benchmark={data.benchmark} engines={sortedEngines} />
-      )}
     </div>
+  )}
+
+  {benchmarkEntry && (
+    <ModelBenchmarkSection entry={benchmarkEntry} seriesEntries={benchmarkSeries} />
   )}
 
   {/* Model Details / Description Section */}

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -37,10 +37,10 @@ const benchmarkSeries = (data.benchmark_series ?? [])
 // Per-token precision pill — colors match benchmark bar palette
 function precisionPill(token: string) {
   const p = token.toUpperCase().trim();
-  if (/Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]/.test(p))
-    return { bg: 'rgba(124,111,160,0.15)', border: '#7C6FA0', color: '#B8ADCC' }; // muted gray-purple (GGUF)
-  if (/FP4|INT4|W4|NF4|Q4|4[_\-]?BIT|AWQ|NVFP4|MXFP4/.test(p))
-    return { bg: 'rgba(168,85,247,0.15)', border: '#A855F7', color: '#D8B4FE' };  // pale purple (4-bit)
+  if (/NVFP4/.test(p))
+    return { bg: 'rgba(168,85,247,0.15)', border: '#A855F7', color: '#D8B4FE' };  // vivid purple (Blackwell-accelerated)
+  if (/FP4|INT4|W4|NF4|Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]|Q4|4[_\-]?BIT|AWQ|MXFP4/.test(p))
+    return { bg: 'rgba(124,111,160,0.15)', border: '#7C6FA0', color: '#B8ADCC' }; // dull gray-purple (other 4-bit)
   if (/FP8|INT8|W8|Q8/.test(p))
     return { bg: 'rgba(118,185,0,0.15)', border: '#76B900', color: '#AADD44' };   // NVIDIA green (8-bit)
   return { bg: 'rgba(0,102,102,0.15)', border: '#008080', color: '#4DD9D9' };     // teal (16-bit+)

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -34,6 +34,30 @@ const benchmarkSeries = (data.benchmark_series ?? [])
   .map((k) => (benchmarksData.models as any[]).find((m) => m.name === k) ?? null)
   .filter((m): m is NonNullable<typeof m> => m !== null);
 
+// Per-token precision pill — colors match benchmark bar palette
+function precisionPill(token: string) {
+  const p = token.toUpperCase().trim();
+  if (/Q[2-8]_K|Q[2-8]_[0-9]|IQ[2-4]/.test(p))
+    return { bg: 'rgba(124,111,160,0.15)', border: '#7C6FA0', color: '#B8ADCC' }; // muted gray-purple (GGUF)
+  if (/FP4|INT4|W4|NF4|Q4|4[_\-]?BIT|AWQ|NVFP4|MXFP4/.test(p))
+    return { bg: 'rgba(168,85,247,0.15)', border: '#A855F7', color: '#D8B4FE' };  // pale purple (4-bit)
+  if (/FP8|INT8|W8|Q8/.test(p))
+    return { bg: 'rgba(118,185,0,0.15)', border: '#76B900', color: '#AADD44' };   // NVIDIA green (8-bit)
+  return { bg: 'rgba(0,102,102,0.15)', border: '#008080', color: '#4DD9D9' };     // teal (16-bit+)
+}
+const precisionTokens = data.precision.split(/[\/,]/).map((t: string) => t.trim()).filter(Boolean);
+
+// Modality icon SVG path data (heroicons 20px solid)
+function modalityIcon(modality: string): string {
+  const icons: Record<string, string> = {
+    'Text':  '<path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>',
+    'Image': '<path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>',
+    'Audio': '<path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clip-rule="evenodd"/>',
+    'Video': '<path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zm12.553 1.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z"/>',
+  };
+  return icons[modality] ?? '';
+}
+
 const inferenceNeedsHfToken = sortedEngines.some((e) => {
   const cmds = [
     e.serve_command_orin,
@@ -65,35 +89,101 @@ const inferenceNeedsHfToken = sortedEngines.some((e) => {
             {data.short_description}
           </p>
           
-          {/* Action Button - Primary CTA only */}
-          <div class="flex flex-wrap gap-3">
-            {/* Run on Jetson - scrolls to inference section */}
+          {/* Page ToC chips */}
+          <div class="flex flex-wrap gap-2 mt-2">
+            {!data.hide_run_button && sortedEngines.length > 0 && (
+              <a
+                href="#run-on-jetson"
+                class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-[#76b900]/60 text-nvidia-gray-200 hover:bg-[#76b900]/10 hover:text-white transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-nvidia-green flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd" />
+                </svg>
+                Command to Run on Jetson
+              </a>
+            )}
+            {benchmarkEntry && (
+              <a
+                href="#model-benchmark"
+                class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-[#76b900]/60 text-nvidia-gray-200 hover:bg-[#76b900]/10 hover:text-white transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-nvidia-green flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zm6-4a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zm6-3a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
+                </svg>
+                Benchmark
+              </a>
+            )}
             <a
-              href="#run-on-jetson"
-              class="inline-flex items-center gap-2 px-4 py-2.5 bg-nvidia-green hover:bg-[#9aeb00] text-black font-semibold rounded-lg transition-colors"
+              href="#model-details"
+              class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-[#76b900]/60 text-nvidia-gray-200 hover:bg-[#76b900]/10 hover:text-white transition-colors"
             >
-              Run on Jetson
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-nvidia-green flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z" />
+              </svg>
+              Model Details
             </a>
           </div>
         </div>
         <div class="bg-nvidia-gray-800 rounded-xl p-8 border border-nvidia-gray-700">
-          <div class="space-y-6">
-            <div class="flex justify-between items-center py-3 border-b border-nvidia-gray-700">
-              <span class="text-nvidia-gray-300 font-medium">Memory Requirement</span>
-              <span class="font-bold text-nvidia-white">{data.memory_requirements}</span>
+          <div class="divide-y divide-nvidia-gray-700">
+
+            {/* Parameters */}
+            {(data.parameters || data.model_size) && (
+              <div class="flex justify-between items-start py-3 gap-4">
+                <span class="text-nvidia-gray-300 font-medium shrink-0">Parameters</span>
+                <span class="font-bold text-nvidia-white text-right">{data.parameters ?? data.model_size}</span>
+              </div>
+            )}
+
+            {/* Modalities */}
+            {(data.modalities?.length > 0 || data.vision_capable !== undefined) && (
+              <div class="flex justify-between items-center py-3 gap-4">
+                <span class="text-nvidia-gray-300 font-medium shrink-0">Modalities</span>
+                <div class="flex flex-wrap gap-1.5 justify-end">
+                  {data.modalities
+                    ? (data.modalities as string[]).map((m) => (
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.14);color:#94A3B8">
+                          <svg class="w-3 h-3 shrink-0" viewBox="0 0 20 20" fill="currentColor"><Fragment set:html={modalityIcon(m)}/></svg>
+                          {m}
+                        </span>
+                      ))
+                    : <span class="font-bold text-nvidia-white">{data.vision_capable ? 'Text, Image' : 'Text'}</span>
+                  }
+                </div>
+              </div>
+            )}
+
+            {/* Context Length */}
+            {data.context_length && (
+              <div class="flex justify-between items-center py-3 gap-4">
+                <span class="text-nvidia-gray-300 font-medium shrink-0">Context Length</span>
+                <span class="font-bold text-nvidia-white">{data.context_length}</span>
+              </div>
+            )}
+
+            {/* License */}
+            {data.license && (
+              <div class="flex justify-between items-start py-3 gap-4">
+                <span class="text-nvidia-gray-300 font-medium shrink-0">License</span>
+                <span class="font-bold text-nvidia-white text-right">{data.license}</span>
+              </div>
+            )}
+
+            {/* Precision */}
+            <div class="flex justify-between items-center py-3 gap-4">
+              <span class="text-nvidia-gray-300 font-medium shrink-0">Precision</span>
+              <div class="flex flex-wrap gap-1.5 justify-end">
+                {precisionTokens.map((token: string) => {
+                  const pill = precisionPill(token);
+                  return (
+                    <span style={`background:${pill.bg};border:1px solid ${pill.border};color:${pill.color};padding:0.2rem 0.6rem;border-radius:9999px;font-size:0.78rem;font-weight:600;letter-spacing:0.02em;`}>
+                      {token}
+                    </span>
+                  );
+                })}
+              </div>
             </div>
-            <div class="flex justify-between items-center py-3 border-b border-nvidia-gray-700">
-              <span class="text-nvidia-gray-300 font-medium">Precision</span>
-              <span class="font-bold text-nvidia-white">{data.precision}</span>
-            </div>
-            <div class="flex justify-between items-center py-3 border-b border-nvidia-gray-700">
-              <span class="text-nvidia-gray-300 font-medium">Vision (VLM)</span>
-              <span class="font-bold text-nvidia-white">{data.vision_capable ? 'Yes' : 'No'}</span>
-            </div>
-            <div class="flex justify-between items-center py-3">
-              <span class="text-nvidia-gray-300 font-medium">Size</span>
-              <span class="font-bold text-nvidia-white">{data.model_size}</span>
-            </div>
+
           </div>
         </div>
       </div>
@@ -143,7 +233,7 @@ const inferenceNeedsHfToken = sortedEngines.some((e) => {
   )}
 
   {/* Model Details / Description Section */}
-  <section class="py-16 bg-nvidia-white">
+  <section id="model-details" class="py-16 bg-nvidia-white">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
         <h2 class="text-3xl font-bold text-nvidia-black">Model Details</h2>


### PR DESCRIPTION
## Summary

- **New `ModelBenchmarkSection` component** — vertical SVG grouped bar chart showing tok/s (or inf/s) throughput per Jetson product. Features C=1/C=8 concurrency toggle and a **Y-axis lock button** (open padlock = auto-scale, closed padlock = fixed scale across all concurrencies, enabling direct visual comparison when toggling).
- **Inference engine toggle** — swap-style selector rendered only when >1 engine has data for a model; subtitle updates dynamically to reflect the selected engine. Ready for multi-engine entries (vLLM, SGLang, llama.cpp, Edge-LLM).
- **`benchmarks.json` restructured** — flat `framework` + `performance` fields replaced with `engines: { "vLLM": { concurrency1, concurrency8 }, ... }` to support multiple engines per model going forward. All 20 existing entries migrated.
- **`benchmark_key` / `benchmark_series` frontmatter** — new optional fields in the models content schema. `benchmark_key` links a model page to its `benchmarks.json` entry; `benchmark_series` lists sibling variants shown as gray reference bars for family-level comparison.
- **17 model pages updated** — `benchmark_key` added; 14+ pages get `benchmark_series` groupings (Gemma 4, Nemotron, Cosmos Reason, Qwen3, Qwen3.5, Qwen3-VL families).

## Screenshots
<img width="2656" height="1056" alt="image" src="https://github.com/user-attachments/assets/8d8ab5ce-f775-41cd-90d3-04382791f9d9" />
<img width="2605" height="1173" alt="image" src="https://github.com/user-attachments/assets/d689f8ba-0593-44c8-8420-c8425ec6066f" />


## Test plan

- [ ] Visit a model page with benchmark data (e.g. `/models/qwen3-30b-a3b/`, `/models/cosmos-reason2-2b/`) — benchmark section appears below the serve section
- [ ] Toggle C=1 ↔ C=8 — bars animate and Y axis rescales
- [ ] Click the lock icon (top-left of chart) — Y axis locks to global max across all concurrencies; switching concurrencies now shows bars at proportional heights for direct comparison
- [ ] Click lock again — returns to auto-scale
- [ ] Hover over bars — tooltip shows model name and value
- [ ] Visit a model without benchmark data — section is absent
- [ ] (Future) Add a second engine key to a `benchmarks.json` entry — engine toggle appears automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)