### PR TITLE
Add Cosmos3 Nano (NVFP4) model card + benchmark

### DIFF
--- a/src/content/models/cosmos3-nano.md
+++ b/src/content/models/cosmos3-nano.md
@@ -1,0 +1,99 @@
+---
+title: "Cosmos3 Nano"
+model_id: "cosmos3-nano"
+short_description: "NVIDIA's compact vision-language reasoning model (16B) with chain-of-thought over text, image, and video — NVFP4 for Blackwell/Thor."
+family: "NVIDIA Cosmos"
+icon: "🧠"
+is_new: true
+order: 5
+type: "Multimodal"
+vision_capable: true
+memory_requirements: "16GB RAM"
+precision: "NVFP4"
+parameters: "16B"
+modalities: ["Text", "Image", "Video"]
+context_length: "256K"
+license: "NVIDIA Open Model License"
+model_size: "7GB"
+hf_checkpoint: "nvidia/Cosmos3-Nano"
+huggingface_url: "https://huggingface.co/nvidia/Cosmos3-Nano"
+minimum_jetson: "Thor"
+hide_run_button: true
+supported_inference_engines:
+  - engine: "vLLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - thor_t4000
+    install_command: |-
+      ngc registry model download-version "nim/nvidia/cosmos3-nano-reasoner:modelopt-nvfp4-full-quantize-final_format_fix"
+    serve_command_thor: |-
+      sudo docker run -it --rm \
+        --runtime=nvidia --network host \
+        -v $MODEL_PATH:/model:ro \
+        --entrypoint "" \
+        vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404 \
+        vllm serve /model \
+          --max-model-len 8192 \
+          --gpu-memory-utilization 0.8 \
+          --trust-remote-code \
+          --limit-mm-per-prompt '{"image": 1, "video": 0}'
+benchmark_key: "Cosmos3 Nano"
+benchmark_series:
+  - "Cosmos Reasoning 2 8B"
+---
+
+[Cosmos3 Nano](https://huggingface.co/nvidia/Cosmos3-Nano) is a compact (16B) vision-language reasoning model from the NVIDIA Cosmos family. It performs chain-of-thought reasoning over text, images, and video, producing text output. This page covers the **NVFP4** checkpoint, which runs natively on Jetson Thor (Blackwell, sm_110) for efficient 4-bit inference.
+
+## Key Capabilities
+
+- **Multimodal Reasoning**: Chain-of-thought over combined image/video + text input
+- **Spatial & Scene Understanding**: Reasoning about objects and relationships in a scene
+- **Video Understanding**: Temporal reasoning across video frames
+- **NVFP4 on Blackwell**: 4-bit (E2M1 with FP8 block scales) weights for high throughput on Thor
+
+## Running with vLLM (NVFP4)
+
+The NVFP4 checkpoint is published on NGC and downloaded via the NGC CLI.
+
+### Step 1: Install and Configure the NGC CLI
+
+```bash
+wget -O ngccli_arm64.zip https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.20.1/files/ngccli_arm64.zip
+unzip ngccli_arm64.zip && chmod u+x ngc-cli/ngc
+export PATH="$PATH:$(pwd)/ngc-cli"
+ngc config set
+```
+
+You will need an [NGC account](https://ngc.nvidia.com/) with access to the model and a valid API key.
+
+### Step 2: Download the NVFP4 Model
+
+```bash
+mkdir -p ~/cosmos3-ngc
+ngc registry model download-version \
+  "nim/nvidia/cosmos3-nano-reasoner:modelopt-nvfp4-full-quantize-final_format_fix" \
+  --dest ~/cosmos3-ngc
+export MODEL_PATH=$(find ~/cosmos3-ngc -maxdepth 2 -name config.json -exec dirname {} \; | head -1)
+```
+
+### Step 3: Serve on Jetson Thor
+
+```bash
+sudo docker run -it --rm --runtime=nvidia --network host \
+  -v $MODEL_PATH:/model:ro \
+  --entrypoint "" \
+  vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404 \
+  vllm serve /model \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.8 \
+    --trust-remote-code \
+    --limit-mm-per-prompt '{"image": 1, "video": 0}'
+```
+
+Send an OpenAI-style chat request with an `image_url` (data URI or http URL) plus a text prompt to exercise the multimodal path.
+
+## Additional Resources
+
+- [NGC NVFP4 Checkpoint](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/models/cosmos3-nano-reasoner) - NVFP4 quantized model for vLLM on Thor
+- [Live VLM WebUI](https://github.com/NVIDIA-AI-IOT/live-vlm-webui) - real-time webcam-to-VLM interface

--- a/src/content/models/cosmos3-nano.md
+++ b/src/content/models/cosmos3-nano.md
@@ -95,5 +95,5 @@ Send an OpenAI-style chat request with an `image_url` (data URI or http URL) plu
 
 ## Additional Resources
 
-- [NGC NVFP4 Checkpoint](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/models/cosmos3-nano-reasoner) - NVFP4 quantized model for vLLM on Thor
+- [NGC NVFP4 Checkpoint](https://catalog.ngc.nvidia.com/orgs/nim/nvidia/models/cosmos3-nano-reasoner/modelopt-nvfp4-full-quantize-final_format_fix) - NVFP4 quantized model for vLLM on Thor
 - [Live VLM WebUI](https://github.com/NVIDIA-AI-IOT/live-vlm-webui) - real-time webcam-to-VLM interface

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -1307,6 +1307,41 @@
           }
         }
       }
+    },
+    {
+      "family": "NVIDIA Cosmos",
+      "name": "Cosmos3 Nano",
+      "releaseDate": "2026-05-30",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
+      "isl": 2048,
+      "osl": 128,
+      "engines": {
+        "vLLM": {
+          "NVFP4*": {
+            "concurrency1": {
+              "t5000": 43,
+              "t4000": 39,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 223,
+              "t4000": 164,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the **Cosmos3 Nano** model page — NVIDIA Cosmos family compact (16B) vision-language reasoning model, NVFP4 for Jetson Thor (Blackwell).

## What's included
- **`src/content/models/cosmos3-nano.md`** — vLLM via the NGC NVFP4 checkpoint:
  - NGC CLI **4.20.1** install + `download-version` (validated end-to-end on Thor T5000)
  - Serve on Thor with **pinned** `vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404`, read-only (`:ro`) weight mount, `--max-model-len 8192`, `--limit-mm-per-prompt '{"image":1,"video":0}'`
  - Supported on `thor_t5000` and `thor_t4000`
- **`src/data/benchmarks.json`** — benchmark entry (Thor T5000 c1/c8 = 43/223, T4000 = 39/164, isl 2048 / osl 128), comparative series vs Cosmos Reasoning 2 8B

## Validation
NGC CLI 4.20.1 verified on Thor (arm64): CLI runs, authenticates, `download-version` pulls 14 files / 7.04 GB (same syntax as 3.x), serves, and benchmarks text c8 = 222 tok/s (matches documented 223).

🤖 Generated with [Claude Code](https://claude.com/claude-code)