### PR TITLE
Benchmarks: backfill measured vLLM data for 8 card-backed models

### DIFF
--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -66,6 +66,7 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf unsloth/gemma-4-E4B:Q4_K_M
+benchmark_key: "Gemma 4 E4B"
 ---
 
 Gemma 4 E4B is a lightweight Gemma 4 model that can be served locally on Jetson with `llama.cpp`. In Google's launch material, E4B is framed as the stronger edge-focused sibling to E2B, combining on-device efficiency with materially better coding, reasoning, and multimodal performance.

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -40,7 +40,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-        vllm serve Kbenkhaled/Qwen3.5-35B-A3B-NVFP4 \
+        vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
@@ -100,7 +100,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-  vllm serve Kbenkhaled/Qwen3.5-35B-A3B-NVFP4 \
+  vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \
     --enable-auto-tool-choice --tool-call-parser qwen3_coder
@@ -127,6 +127,6 @@ This model supports **Multi-Token Prediction (MTP)** speculative decoding, which
 ## Additional Resources
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) - Original model weights
-- [NVFP4 Checkpoint (Thor)](https://huggingface.co/Kbenkhaled/Qwen3.5-35B-A3B-NVFP4) - Quantized for Jetson Thor
+- [NVFP4 Checkpoint (Thor)](https://huggingface.co/AxionML/Qwen3.5-35B-A3B-NVFP4) - Quantized for Jetson Thor
 - [W4A16 Checkpoint (Orin)](https://huggingface.co/Kbenkhaled/Qwen3.5-35B-A3B-quantized.w4a16) - Quantized for Jetson Orin
 

--- a/src/content/models/qwen3-5-4b.md
+++ b/src/content/models/qwen3-5-4b.md
@@ -48,6 +48,7 @@ supported_inference_engines:
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder
+benchmark_key: "Qwen3.5-4B"
 ---
 
 Qwen3.5 4B offers a balanced point in the Qwen3.5 family for local multimodal instruction following, visual understanding, and agent-style workloads on Jetson.

--- a/src/content/models/qwen3-5-9b.md
+++ b/src/content/models/qwen3-5-9b.md
@@ -31,7 +31,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-orin \
-        vllm serve Kbenkhaled/Qwen3.5-9B-quantized.w4a16 \
+        vllm serve RedHatAI/Qwen3.5-9B-quantized.w4a16 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
@@ -41,12 +41,13 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-        vllm serve Kbenkhaled/Qwen3.5-9B-NVFP4 \
+        vllm serve AxionML/Qwen3.5-9B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder
+benchmark_key: "Qwen3.5-9B"
 ---
 
 Qwen3.5 9B is a dense vision-language model in the Qwen3.5 family aimed at stronger reasoning, visual understanding, and agentic behavior on Jetson. This entry uses a W4A16 checkpoint on Jetson Orin and an NVFP4 checkpoint on Jetson Thor.
@@ -67,6 +68,6 @@ Qwen3.5 9B is a dense vision-language model in the Qwen3.5 family aimed at stron
 ## Additional Resources
 
 - [Original Model](https://huggingface.co/Qwen/Qwen3.5-9B) - Base Qwen3.5 9B checkpoint
-- [W4A16 Checkpoint](https://huggingface.co/Kbenkhaled/Qwen3.5-9B-quantized.w4a16) - Jetson Orin checkpoint
-- [NVFP4 Checkpoint](https://huggingface.co/Kbenkhaled/Qwen3.5-9B-NVFP4) - Jetson Thor checkpoint
+- [W4A16 Checkpoint](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w4a16) - Jetson Orin checkpoint
+- [NVFP4 Checkpoint](https://huggingface.co/AxionML/Qwen3.5-9B-NVFP4) - Jetson Thor checkpoint
 

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -35,6 +35,7 @@ benchmark:
     concurrency1: 13
     concurrency8: 55
     ttftMs: 0
+benchmark_key: "Qwen3.6-27B"
 ---
 
 Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 27 billion parameters, it delivers strong performance across complex reasoning, coding, and language understanding tasks.

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -51,6 +51,7 @@ benchmark:
     concurrency1: 42
     concurrency8: 136
     ttftMs: 0
+benchmark_key: "Qwen3.6-35B-A3B"
 ---
 
 Qwen3.6 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.6 family. It features 35 billion total parameters with only 3 billion active during inference, delivering strong performance with excellent efficiency on edge devices.

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -256,6 +256,44 @@
               "dgx_spark": null
             }
           }
+        },
+        "vLLM": {
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 26,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 132,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "BF16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 20,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 97,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
         }
       }
     },
@@ -771,7 +809,7 @@
         "vLLM": {
           "NVFP4": {
             "concurrency1": {
-              "t5000": 35,
+              "t5000": 49,
               "t4000": null,
               "agx_orin_64gb": null,
               "orin_nx_16gb": null,
@@ -779,7 +817,7 @@
               "dgx_spark": null
             },
             "concurrency8": {
-              "t5000": 125,
+              "t5000": 139,
               "t4000": null,
               "agx_orin_64gb": null,
               "orin_nx_16gb": null,
@@ -890,6 +928,46 @@
           "orin_nx_16gb": null,
           "orin_nano_8gb": null
         }
+      },
+      "engines": {
+        "vLLM": {
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 38,
+              "t4000": 36,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 128,
+              "t4000": 110,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 29,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 83,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        }
       }
     },
     {
@@ -920,6 +998,28 @@
           "agx_orin_64gb": null,
           "orin_nx_16gb": null,
           "orin_nano_8gb": null
+        }
+      },
+      "engines": {
+        "vLLM": {
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 7,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 21,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
         }
       }
     },
@@ -1126,6 +1226,44 @@
               "t5000": null,
               "t4000": null,
               "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        },
+        "vLLM": {
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 77,
+              "t4000": 66,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 523,
+              "t4000": 405,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "BF16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 32,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 191,
               "orin_nx_16gb": null,
               "orin_nano_8gb": null,
               "dgx_spark": null
@@ -1344,6 +1482,24 @@
               "orin_nano_8gb": null,
               "dgx_spark": null
             }
+          },
+          "BF16": {
+            "concurrency1": {
+              "t5000": 47,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 123,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
           }
         }
       }
@@ -1445,6 +1601,165 @@
               "t5000": 223,
               "t4000": 164,
               "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        }
+      }
+    },
+    {
+      "family": "Gemma",
+      "name": "Gemma 4 E4B",
+      "releaseDate": "2026-04-02",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
+      "isl": 2048,
+      "osl": 128,
+      "engines": {
+        "vLLM": {
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 45,
+              "t4000": 39,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 275,
+              "t4000": 199,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 32,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 147,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        }
+      }
+    },
+    {
+      "family": "Qwen",
+      "name": "Qwen3.5-4B",
+      "releaseDate": "2026-02-27",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
+      "isl": 2048,
+      "osl": 128,
+      "engines": {
+        "vLLM": {
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 60,
+              "t4000": 58,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 292,
+              "t4000": 258,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 28,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 122,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          }
+        }
+      }
+    },
+    {
+      "family": "Qwen",
+      "name": "Qwen3.5-9B",
+      "releaseDate": "2026-02-27",
+      "capabilities": {
+        "language": true,
+        "vision": true,
+        "audio": false,
+        "vla": false
+      },
+      "isl": 2048,
+      "osl": 128,
+      "engines": {
+        "vLLM": {
+          "NVFP4": {
+            "concurrency1": {
+              "t5000": 27,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 154,
+              "t4000": null,
+              "agx_orin_64gb": null,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            }
+          },
+          "W4A16": {
+            "concurrency1": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 17,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": null,
+              "t4000": null,
+              "agx_orin_64gb": 73,
               "orin_nx_16gb": null,
               "orin_nano_8gb": null,
               "dgx_spark": null


### PR DESCRIPTION
Exact port of jetson-ai-lab-stg PR #17 (reviewed/deployed on staging).

**Fills on existing entries**: Gemma 4 E2B (new vLLM tab: NVFP4 + BF16), Nemotron3 Nano 4B (new vLLM tab), Qwen3.6-35B-A3B + Qwen3.6-27B (first data), GPT-OSS-20B (BF16 row)
**New entries (cards exist)**: Gemma 4 E4B, Qwen3.5-4B, Qwen3.5-9B
**Corrections**: Qwen3.5-9B NVFP4 T5000 → 27/154 and Qwen3.5-35B-A3B → 49/139, remeasured with AxionML checkpoints after finding the prior community quants undersold Thor by 40-60%
**Card wiring**: benchmark_key on 5 cards (chart renders only with a key); Qwen3.5-9B/35B-A3B serve commands updated to the checkpoints the numbers were measured with

All values traced to JAB result JSONs (Thor T5000/T4000, AGX Orin 64GB; isl 2048 / osl 128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)