### PR TITLE
docs: add contributor guide and refresh project docs

### DIFF
--- a/CONTENT_GUIDE.md
+++ b/CONTENT_GUIDE.md
@@ -1,29 +1,30 @@
 # Content Management Guide
 
-This guide explains how to manage content for Jetson AI Lab - Redesign using Markdown and JSON files.
+This guide explains how to manage content for Jetson AI Lab using Markdown, MDX, and JSON files. Content is data-driven, so most updates require no changes to layout code.
 
-## Overview
-
-The website now uses a content-driven approach where all content is defined in Markdown and JSON files, making it easy to update without touching HTML code.
+The authoritative schemas live in `src/content/config.ts`. This guide summarizes them; if the two ever disagree, `config.ts` wins. See also `CONTRIBUTING.md`, `TUTORIAL_TEMPLATE.md`, and `docs/jetson-matrix-and-run-modal.md`.
 
 ## File Structure
 
 ```
 src/
 ├── content/
-│   ├── home.json              # Home page content
-│   ├── models/                # Model documentation
-│   │   ├── gemma-3n.md
-│   │   └── llama-4.md
-│   ├── tutorials/             # Tutorial guides
-│   │   └── whisper-jetson.md
-│   └── posts/                 # Blog posts
-│       └── welcome.md
+│   ├── home.json        # Home page content (hero, features, stats, featured models)
+│   ├── models/          # Model pages (Markdown + frontmatter)
+│   ├── tutorials/       # Tutorials, grouped in subfolders (Markdown/MDX)
+│   ├── projects/        # Community project entries
+│   └── gtc26/           # GTC workshop lab content
+├── data/
+│   ├── benchmarks.json  # Benchmark chart data (joined to models by benchmark_key)
+│   └── categories.json  # Tutorial category display metadata
+└── pages/               # Astro routes (including tutorial page wrappers)
 ```
 
-## Home Page Content (`src/content/home.json`)
+Active content collections are `tutorials`, `models`, `projects`, and `gtc26`.
 
-The home page content is defined in JSON format for easy editing:
+## Home Page (`src/content/home.json`)
+
+Edit `src/content/home.json` to update the hero, feature cards, stats, and featured models. Changes appear automatically. Match the existing JSON shape, for example:
 
 ```json
 {
@@ -32,27 +33,16 @@ The home page content is defined in JSON format for easy editing:
     "subtitle": "Run the latest AI models locally",
     "description": "Discover optimized models for Jetson devices..."
   },
-  "features": [
-    {
-      "title": "Local & Offline",
-      "description": "Run AI models directly on your Jetson device...",
-      "icon": "🚀"
-    }
-  ],
-  "stats": [
-    {
-      "number": "15+",
-      "label": "Optimized Models"
-    }
-  ],
   "featuredModels": [
     {
       "title": "Gemma 3n",
       "description": "Google's latest lightweight language model...",
       "badge": "NEW",
       "performance": {
-        "speed": "2.5x faster",
-        "accuracy": "95% accuracy"
+        "tokensPerSecond": "25-35 tokens/s",
+        "memoryUsage": "4GB RAM",
+        "quantization": "4-bit (GPTQ)",
+        "modelSize": "2.1GB"
       },
       "devices": ["Jetson Orin", "Jetson Xavier"],
       "link": "/models/gemma-3n"
@@ -61,147 +51,89 @@ The home page content is defined in JSON format for easy editing:
 }
 ```
 
-### How to Update Home Page
+## Models (`src/content/models/`)
 
-1. Edit `src/content/home.json`
-2. Save the file
-3. The changes will automatically appear on the home page
+Each model is a Markdown file whose frontmatter drives the Model Details sidebar and the "Run on Jetson" UI. Required fields are `title`, `short_description`, and `precision`.
 
-## Model Documentation (`src/content/models/`)
+A model must also provide runnable content, or the build fails: supply `serving.entries` and/or `supported_inference_engines`, meaningful `one_shot_inference` commands, or set `hide_run_button: true`.
 
-Each model has its own Markdown file with frontmatter and detailed content.
-
-### Frontmatter Structure
+Example frontmatter:
 
 ```yaml
 ---
-title: "Model Name"
-description: "Brief description"
-category: "Language Models"
-tags: ["tag1", "tag2"]
-image: "/images/models/model.jpg"
-performance:
-  speed: "2.5x faster"
-  accuracy: "95% accuracy"
-  memory: "4GB RAM required"
-devices: ["Jetson Orin", "Jetson Xavier"]
-installation: |
-  ```bash
-  # Installation commands
-  ```
-usage: |
-  ```python
-  # Usage example
-  ```
-isHighlighted: true
-isNew: true
+title: "Gemma 3 4B"
+short_description: "Google's versatile 4 billion parameter model"
+family: "Google Gemma3"
+precision: "W4A16"
+parameters: "4B"
+modalities: ["Text", "Image"]
+context_length: "128K"
+license: "Gemma Terms of Service"
+minimum_jetson: "Orin Nano"
+supported_inference_engines:
+  - engine: "Ollama"
+    type: "Container"
+    modules_supported: [thor_t5000, orin_agx_64, orin_nano_8]
+    serve_command_orin: ollama pull gemma3:4b && ollama serve
+    serve_command_thor: ollama pull gemma3:4b && ollama serve
 ---
 ```
 
-### Content Structure
+To wire benchmark charts, set `benchmark_key` to match a `name` in `src/data/benchmarks.json`. A mismatch does not fail the build; the chart simply will not render, so confirm it on `/models/<slug>`.
 
-The Markdown content can include:
-
-- **Overview**: Model description and key features
-- **Performance Specifications**: Tables with metrics
-- **Use Cases**: List of applications
-- **Installation**: Step-by-step setup
-- **Quick Start**: Basic usage examples
-- **Advanced Usage**: Complex scenarios
-- **Device Compatibility**: Supported devices
-- **Troubleshooting**: Common issues and solutions
-- **Related Models**: Links to other models
-
-### How to Add a New Model
-
-1. Create a new file in `src/content/models/model-name.md`
-2. Add the frontmatter with all required fields
-3. Write the content in Markdown
-4. Add the model to `home.json` featuredModels if needed
+For inference commands, the module matrix, benchmark wiring, and OOM/blocked handling, follow `docs/jetson-matrix-and-run-modal.md`.
 
 ## Tutorials (`src/content/tutorials/`)
 
-Tutorials are written in Markdown with specific frontmatter:
+A tutorial needs two files:
+
+1. Content in `src/content/tutorials/<subfolder>/<slug>.md` (or `.mdx` for interactive components).
+2. A page wrapper in `src/pages/tutorials/<slug>.astro` that passes the slug to `TutorialLayout`.
+
+Required frontmatter is `title`, `description`, `category`, and `tags`. Include `authors` when adding or substantially updating a tutorial.
 
 ```yaml
 ---
-title: "Tutorial Title"
-description: "Brief description"
-difficulty: "Beginner"  # Beginner, Intermediate, Advanced
-duration: "15 min"
-tags: ["tag1", "tag2"]
-model: "model-name"
-publishedAt: 2024-01-15
+title: "Ollama on Jetson"
+description: "Install and run Ollama on your Jetson device."
+category: "Fundamentals"
+section: "Inference Engines"
+order: 3
+tags: ["ollama", "llm", "jetson"]
+authors:
+  - name: "Dustin Franklin"
+    github: "dusty-nv"
 ---
 ```
 
-### Tutorial Content
+Valid `category` values: `Text`, `Image`, `Audio`, `Applications`, `VLM`, `VLA`, `Fundamentals`, `Setup`, `Workshops`, `Model Optimization`. Optional fields include `section`, `order`, `model`, `featured`, `isNew`, and `hero_image`. Use `TUTORIAL_TEMPLATE.md` for the page wrapper pattern and MDX components (tabs, admonitions, Mermaid).
 
-Tutorials can include:
+## Community Projects (`src/content/projects/`)
 
-- **Prerequisites**: Requirements and setup
-- **Installation**: Step-by-step installation
-- **Basic Usage**: Simple examples
-- **Advanced Usage**: Complex scenarios
-- **Troubleshooting**: Common issues
-- **Use Cases**: Practical applications
+Each project entry requires `title`, `description`, `author`, `date`, `source` (one of `GitHub`, `Hackster`, `YouTube`, `NVIDIA`, `JetsonHacks`, `Medium`, `Seeed`, `Other`), and `link` (a full URL). Optional fields include `image`, `video`, `featured`, `tags`, and `jetson`.
 
-## Blog Posts (`src/content/posts/`)
+## Assets
 
-Blog posts use this frontmatter structure:
-
-```yaml
----
-title: "Post Title"
-description: "Brief description"
-author: "Author Name"
-publishedAt: 2024-01-15
-tags: ["tag1", "tag2"]
-featured: true
----
-```
-
-## Benefits of This Approach
-
-1. **Easy Content Management**: Update content without touching code
-2. **Version Control**: All content is tracked in Git
-3. **Structured Data**: Consistent format across all content
-4. **Separation of Concerns**: Content separate from presentation
-5. **Scalable**: Easy to add new models, tutorials, and posts
-6. **Markdown Support**: Rich formatting with code blocks, tables, etc.
-
-## Adding New Content
-
-### New Model
-1. Create `src/content/models/model-name.md`
-2. Add to `home.json` featuredModels if needed
-3. Update models page if required
-
-### New Tutorial
-1. Create `src/content/tutorials/tutorial-name.md`
-2. Follow the frontmatter structure
-3. Write detailed step-by-step content
-
-### New Blog Post
-1. Create `src/content/posts/post-name.md`
-2. Add frontmatter with required fields
-3. Write content in Markdown
-
-## Best Practices
-
-1. **Consistent Formatting**: Use the same structure across similar content
-2. **Clear Descriptions**: Write concise but informative descriptions
-3. **Code Examples**: Include working code examples
-4. **Images**: Use descriptive image paths
-5. **Tags**: Use consistent tagging system
-6. **Links**: Include relevant internal and external links
+- Store images and media under `public/` and reference them with absolute paths (for example `/images/models/model.jpg`).
+- Place downloadable scripts under `public/code-samples/` and link to them from the relevant tutorial.
 
 ## Development
 
-To run the development server:
+Run the development server for a live preview:
 
 ```bash
 npm run dev
 ```
 
-The site will automatically reload when you make changes to content files. 
+Before opening a pull request, run a full production build. It runs schema validation across all collections, which the dev server alone does not:
+
+```bash
+npm run build
+```
+
+## Best Practices
+
+- Follow the structure of existing files in the same collection.
+- Write concise, informative descriptions and use consistent tags.
+- Include working code examples and verify commands on the hardware you name.
+- Use descriptive image names and meaningful alternative text.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Jetson AI Lab
+
+Jetson AI Lab is a public, community-facing project. We invite developers both inside and outside NVIDIA to publish their Jetson work here and improve the site through pull requests.
+
+You can contribute:
+
+- Jetson tutorials, applications, and downloadable code samples
+- Community projects built with Jetson
+- New or updated model pages and verified inference instructions
+- Reproducible benchmarks with hardware and software details
+- Bug fixes, accessibility improvements, and website features
+- Documentation corrections and troubleshooting guidance
+
+Submit your pull request to the `main` branch. One of the project's core contributors will review it, provide feedback when needed, and merge it after the required checks pass.
+
+## Before You Start
+
+- Search [existing issues](https://github.com/NVIDIA-AI-IOT/jetson-ai-lab/issues) and pull requests.
+- Open an issue first for large features or architecture changes.
+- Keep each pull request focused on one change.
+- Only submit work you have the right to contribute under the repository's [MIT License](LICENSE).
+- Never include confidential information, credentials, customer data, or private NVIDIA material.
+
+## Set Up
+
+Install Git, Node.js 20, and npm. Fork the repository on GitHub, then:
+
+```bash
+git clone https://github.com/YOUR-GITHUB-USERNAME/jetson-ai-lab.git
+cd jetson-ai-lab
+git remote add upstream https://github.com/NVIDIA-AI-IOT/jetson-ai-lab.git
+npm ci
+npm run dev
+```
+
+The local site runs at `http://localhost:4321`.
+
+Create a branch from the latest `main`:
+
+```bash
+git checkout main
+git pull --ff-only upstream main
+git checkout -b docs/your-change
+```
+
+## Where to Contribute
+
+| Contribution | Location |
+|---|---|
+| Tutorials | `src/content/tutorials/` and `src/pages/tutorials/` |
+| Model pages | `src/content/models/` |
+| Community projects | `src/content/projects/` |
+| Benchmarks | `src/data/benchmarks.json` |
+| Downloadable scripts | `public/code-samples/` |
+| Homepage content | `src/content/home.json` |
+
+For tutorials, follow `TUTORIAL_TEMPLATE.md` and include `authors` in the frontmatter. For model pages and inference commands, follow `docs/jetson-matrix-and-run-modal.md` and existing model examples. All content must match the schemas in `src/content/config.ts`.
+
+Verify Jetson commands on the hardware and JetPack version you name. Include the source and methodology for benchmark claims, use meaningful image alternative text, and clearly identify anything you did not test.
+
+Follow existing Astro, TypeScript, Tailwind, accessibility, and responsive-design patterns for code changes. Explain any new dependency in the pull request.
+
+## Validate
+
+Before opening a pull request, run:
+
+```bash
+npm ci
+npx playwright install chromium
+npm run build
+```
+
+Also review affected pages with `npm run dev`. Include screenshots for visual changes and your tested Jetson hardware/software configuration when applicable.
+
+## Open a Pull Request
+
+Push your branch:
+
+```bash
+git push -u origin docs/your-change
+```
+
+Open a pull request to:
+
+```text
+NVIDIA-AI-IOT/jetson-ai-lab → main
+```
+
+Describe the change, link any related issue, and list how you tested it. By submitting a pull request, you confirm that you have the right to contribute the work under the repository's MIT License.
+
+One of our core contributors will review the pull request and may request changes. After approval and successful checks, a core contributor will merge it. You do not need direct write access.
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/NVIDIA-AI-IOT/jetson-ai-lab/issues) for bugs and feature requests. Include reproduction steps, expected and actual behavior, relevant versions, and sanitized logs.
+
+Do not report security vulnerabilities publicly. Use NVIDIA's [security vulnerability reporting process](https://www.nvidia.com/en-us/product-security/report-vulnerability/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ You can contribute:
 - Jetson tutorials, applications, and downloadable code samples
 - Community projects built with Jetson
 - New or updated model pages and verified inference instructions
-- Reproducible benchmarks with hardware and software details
 - Bug fixes, accessibility improvements, and website features
 - Documentation corrections and troubleshooting guidance
 
@@ -89,6 +88,22 @@ NVIDIA-AI-IOT/jetson-ai-lab → main
 Describe the change, link any related issue, and list how you tested it. By submitting a pull request, you confirm that you have the right to contribute the work under the repository's MIT License.
 
 One of our core contributors will review the pull request and may request changes. After approval and successful checks, a core contributor will merge it. You do not need direct write access.
+
+### Signing your commits (recommended)
+
+We recommend signing off your commits with a [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The sign-off certifies that you have the right to submit the contribution under the project's license and provides a clear record of authorship. It is encouraged but not required.
+
+Add a sign-off with the `-s` flag:
+
+```bash
+git commit -s -m "Add a Jetson setup troubleshooting section"
+```
+
+This appends a trailer matching your commit author identity:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Jetson AI Lab pairs a modern Astro frontend with a content-driven workflow, enab
 
 ### Prerequisites
 
-- Node.js 20 and npm (matches CI)
+- Node.js 20 and npm 
 - Git
 
 ### Local Development

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The NVIDIA Jetson AI Lab is your guide to running generative AI models entirely 
 
 ## About
 
-Jetson AI Lab pairs a modern Astro frontend with a content-driven workflow, enabling new tutorials, models, and posts to be published without touching layout code.
+Jetson AI Lab pairs a modern Astro frontend with a content-driven workflow, enabling new tutorials, models, and community projects to be published without touching layout code.
 
 ### Key Features
 
@@ -35,12 +35,15 @@ Jetson AI Lab pairs a modern Astro frontend with a content-driven workflow, enab
 │   ├── content/              Markdown and JSON content repositories
 │   │   ├── home.json         Homepage metrics and featured models
 │   │   ├── models/           Model deep dives authored in Markdown
-│   │   ├── posts/            Blog articles
-│   │   └── tutorials/        Long-form tutorials with frontmatter
+│   │   ├── tutorials/        Long-form tutorials with frontmatter
+│   │   ├── projects/         Community project entries
+│   │   └── gtc26/            GTC workshop lab content
+│   ├── data/                 Benchmark and category data (JSON)
 │   ├── layouts/              Base layouts for pages and tutorials
 │   └── pages/                Astro routes for the site
 ├── public/
 │   ├── archive/              Legacy MkDocs documentation (static)
+│   ├── code-samples/         Downloadable tutorial scripts
 │   └── images/               Static assets
 ├── astro.config.mjs          Astro configuration with redirects
 ├── tailwind.config.mjs       Tailwind theme definitions
@@ -51,7 +54,7 @@ Jetson AI Lab pairs a modern Astro frontend with a content-driven workflow, enab
 
 ### Prerequisites
 
-- Node.js 18+ and npm
+- Node.js 20 and npm (matches CI)
 - Git
 
 ### Local Development
@@ -95,6 +98,8 @@ npm run preview
 
 ## Content Authoring
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for collection schemas, validation requirements, and contribution workflow.
+
 ### Adding Tutorials
 
 1. Create a Markdown file in `src/content/tutorials/` with appropriate frontmatter
@@ -112,7 +117,7 @@ Edit `src/content/home.json` to update hero metrics, featured models, and stats.
 ### Content Tips
 
 - Use Markdown headings and tables for consistent styling
-- Set `difficulty` in tutorial frontmatter: `Beginner`, `Intermediate`, or `Advanced`
+- Match tutorial frontmatter to `src/content/config.ts` (`title`, `description`, `category`, `tags`, and optional `authors`)
 - Store media assets under `public/` and reference with absolute paths
 
 ## URL Redirects
@@ -149,15 +154,13 @@ Legacy MkDocs documentation is preserved at `/archive/` with a deprecation banne
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/new-tutorial`)
-3. Commit your changes (`git commit -m 'Add new tutorial'`)
-4. Push to the branch (`git push origin feature/new-tutorial`)
-5. Open a Pull Request
+Developers inside and outside NVIDIA are invited to contribute tutorials, Jetson projects, model updates, code samples, benchmarks, and site improvements. Open your pull request against `main`, and one of our core contributors will review it.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, publishing guidelines, validation requirements, and the pull request process.
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+Licensed under the [MIT License](LICENSE).
 
 ## Contact
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Official NVIDIA experience for running Jetson-optimized generative AI models locally",
   "author": "NVIDIA Corporation",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -38,7 +38,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/nvidia/jetson-ai-lab.git"
+    "url": "https://github.com/NVIDIA-AI-IOT/jetson-ai-lab.git"
   },
   "homepage": "https://www.jetson-ai-lab.com"
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -227,7 +227,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
             <li><a href="https://www.nvidia.com/en-us/contact/" target="_blank" class="hover:text-nvidia-white transition-colors duration-200">Contact</a></li>
           </ul>
           <p class="text-nvidia-gray-400 text-sm text-center">
-            © 2026 NVIDIA Corporation. All rights reserved.
+            © {new Date().getFullYear()} NVIDIA Corporation. All rights reserved.
           </p>
         </div>
       </div>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -61,7 +61,7 @@
 
       <div class="text-center mt-8">
         <p class="text-sm text-nvidia-gray-500 font-nvidia">
-          © 2026 NVIDIA Corporation. All rights reserved.
+          © {new Date().getFullYear()} NVIDIA Corporation. All rights reserved.
         </p>
       </div>
     </div>


### PR DESCRIPTION
- Add CONTRIBUTING.md inviting internal and external developers to open PRs against main for core-contributor review
- Update README contribution/content sections, fix stale posts collection references, correct project structure, and state MIT license
- Rewrite CONTENT_GUIDE.md to match current content collection schemas (models, tutorials, projects, gtc26)
- Fix package.json license (MIT) and repository URL (NVIDIA-AI-IOT)
- Render footer copyright year dynamically in Layout.astro and login.astro