### PR TITLE
docs(models): use vllm/vllm-openai:latest for Jetson Thor serve commands

### DIFF
--- a/src/content/models/cosmos-reason1-7b.md
+++ b/src/content/models/cosmos-reason1-7b.md
@@ -38,7 +38,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         -e HF_TOKEN=$HF_TOKEN -v $HOME/.cache/huggingface:/root/.cache/huggingface vllm/vllm-openai:latest \
-        vllm serve nvidia/Cosmos-Reason1-7B --max-model-len 8192 --gpu-memory-utilization 0.6 --reasoning-parser qwen3
+        nvidia/Cosmos-Reason1-7B --max-model-len 8192 --gpu-memory-utilization 0.6 --reasoning-parser qwen3
 ---
 
 [NVIDIA Cosmos Reason 1 7B](https://huggingface.co/nvidia/Cosmos-Reason1-7B) is a reasoning vision-language model designed for physical AI and robotics applications. With 7 billion parameters, it provides strong reasoning capabilities for understanding physical world interactions, spatial relationships, and complex scene analysis.

--- a/src/content/models/cosmos-reason1-7b.md
+++ b/src/content/models/cosmos-reason1-7b.md
@@ -37,7 +37,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        -e HF_TOKEN=$HF_TOKEN -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        -e HF_TOKEN=$HF_TOKEN -v $HOME/.cache/huggingface:/root/.cache/huggingface vllm/vllm-openai:latest \
         vllm serve nvidia/Cosmos-Reason1-7B --max-model-len 8192 --gpu-memory-utilization 0.6 --reasoning-parser qwen3
 ---
 
@@ -57,7 +57,7 @@ This model can be pulled directly from HuggingFace and served with vLLM — no m
 
 | | Jetson AGX Thor | Jetson AGX Orin (64GB) |
 |---|---|---|
-| **vLLM Container** | `ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor` | `ghcr.io/nvidia-ai-iot/vllm:latest-jetson-orin` |
+| **vLLM Container** | `vllm/vllm-openai:latest` | `ghcr.io/nvidia-ai-iot/vllm:latest-jetson-orin` |
 | **Max Model Length** | 8192 tokens | 8192 tokens |
 | **GPU Memory Util** | 0.6 | 0.8 |
 

--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
       sudo docker run -it --rm \
         --runtime=nvidia --network host \
         -v $MODEL_PATH:/models/cosmos-reason2-2b:ro \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve /models/cosmos-reason2-2b \
           --max-model-len 8192 \
           --gpu-memory-utilization 0.8 \
@@ -137,7 +137,7 @@ sudo sysctl -w vm.drop_caches=3
 sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-2b:ro \
   -v ${HOME}/.cache/vllm:/root/.cache/vllm \
-  ghcr.io/nvidia-ai-iot/vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 \
+  vllm/vllm-openai:latest \
   vllm serve /models/cosmos-reason2-2b \
     --served-model-name nvidia/cosmos-reason2-2b-fp8 \
     --max-model-len 8192 \

--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -46,7 +46,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $MODEL_PATH:/models/cosmos-reason2-2b:ro \
         vllm/vllm-openai:latest \
-        vllm serve /models/cosmos-reason2-2b \
+        /models/cosmos-reason2-2b \
           --max-model-len 8192 \
           --gpu-memory-utilization 0.8 \
           --reasoning-parser qwen3 \
@@ -138,7 +138,7 @@ sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-2b:ro \
   -v ${HOME}/.cache/vllm:/root/.cache/vllm \
   vllm/vllm-openai:latest \
-  vllm serve /models/cosmos-reason2-2b \
+  /models/cosmos-reason2-2b \
     --served-model-name nvidia/cosmos-reason2-2b-fp8 \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.8 \

--- a/src/content/models/cosmos-reason2-8b.md
+++ b/src/content/models/cosmos-reason2-8b.md
@@ -46,7 +46,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
         vllm/vllm-openai:latest \
-        vllm serve /models/cosmos-reason2-8b \
+        /models/cosmos-reason2-8b \
           --max-model-len 8192 \
           --gpu-memory-utilization 0.8 \
           --reasoning-parser qwen3 \
@@ -129,7 +129,7 @@ sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
   -v ${HOME}/.cache/vllm:/root/.cache/vllm \
   vllm/vllm-openai:latest \
-  vllm serve /models/cosmos-reason2-8b \
+  /models/cosmos-reason2-8b \
     --served-model-name nvidia/cosmos-reason2-8b-fp8 \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.7 \

--- a/src/content/models/cosmos-reason2-8b.md
+++ b/src/content/models/cosmos-reason2-8b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
       sudo docker run -it --rm \
         --runtime=nvidia --network host \
         -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve /models/cosmos-reason2-8b \
           --max-model-len 8192 \
           --gpu-memory-utilization 0.8 \
@@ -128,7 +128,7 @@ sudo sysctl -w vm.drop_caches=3
 sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
   -v ${HOME}/.cache/vllm:/root/.cache/vllm \
-  ghcr.io/nvidia-ai-iot/vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 \
+  vllm/vllm-openai:latest \
   vllm serve /models/cosmos-reason2-8b \
     --served-model-name nvidia/cosmos-reason2-8b-fp8 \
     --max-model-len 8192 \

--- a/src/content/models/cosmos3-nano.md
+++ b/src/content/models/cosmos3-nano.md
@@ -32,7 +32,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $MODEL_PATH:/model:ro \
         --entrypoint "" \
-        vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404 \
+        vllm/vllm-openai:latest \
         vllm serve /model \
           --max-model-len 8192 \
           --gpu-memory-utilization 0.8 \
@@ -83,7 +83,7 @@ export MODEL_PATH=$(find ~/cosmos3-ngc -maxdepth 2 -name config.json -exec dirna
 sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/model:ro \
   --entrypoint "" \
-  vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404 \
+  vllm/vllm-openai:latest \
   vllm serve /model \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.8 \

--- a/src/content/models/gemma3-12b.md
+++ b/src/content/models/gemma3-12b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/gemma-3-12b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/gemma3-12b.md
+++ b/src/content/models/gemma3-12b.md
@@ -46,7 +46,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/gemma-3-12b-it-quantized.w4a16
+        RedHatAI/gemma-3-12b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/gemma3-1b.md
+++ b/src/content/models/gemma3-1b.md
@@ -47,7 +47,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve google/gemma-3-1b-it
 one_shot_inference:
   modules_supported:

--- a/src/content/models/gemma3-1b.md
+++ b/src/content/models/gemma3-1b.md
@@ -48,7 +48,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve google/gemma-3-1b-it
+        google/gemma-3-1b-it
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/gemma3-270m.md
+++ b/src/content/models/gemma3-270m.md
@@ -48,7 +48,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve google/gemma-3-270m-it
+        google/gemma-3-270m-it
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/gemma3-270m.md
+++ b/src/content/models/gemma3-270m.md
@@ -47,7 +47,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve google/gemma-3-270m-it
 one_shot_inference:
   modules_supported:

--- a/src/content/models/gemma3-27b.md
+++ b/src/content/models/gemma3-27b.md
@@ -44,7 +44,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/gemma-3-27b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/gemma3-27b.md
+++ b/src/content/models/gemma3-27b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/gemma-3-27b-it-quantized.w4a16
+        RedHatAI/gemma-3-27b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/gemma3-4b.md
+++ b/src/content/models/gemma3-4b.md
@@ -47,7 +47,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/gemma-3-4b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/gemma3-4b.md
+++ b/src/content/models/gemma3-4b.md
@@ -48,7 +48,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/gemma-3-4b-it-quantized.w4a16
+        RedHatAI/gemma-3-4b-it-quantized.w4a16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/gemma4-12b.md
+++ b/src/content/models/gemma4-12b.md
@@ -29,7 +29,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         --entrypoint "" \
-        vllm/vllm-openai:v0.24.0-aarch64-ubuntu2404 \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/gemma-4-12B-it-NVFP4 \
           --gpu-memory-utilization 0.7 \
           --max-model-len 8192 \

--- a/src/content/models/gemma4-26b-a4b.md
+++ b/src/content/models/gemma4-26b-a4b.md
@@ -40,7 +40,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
-          ghcr.io/nvidia-ai-iot/vllm:gemma4-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4 \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \

--- a/src/content/models/gemma4-26b-a4b.md
+++ b/src/content/models/gemma4-26b-a4b.md
@@ -41,7 +41,7 @@ serving:
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           vllm/vllm-openai:latest \
-          vllm serve bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4 \
+          bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4 \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \
             --reasoning-parser gemma4 \

--- a/src/content/models/gemma4-31b.md
+++ b/src/content/models/gemma4-31b.md
@@ -40,7 +40,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
-          ghcr.io/nvidia-ai-iot/vllm:gemma4-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve nvidia/Gemma-4-31B-IT-NVFP4 \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \

--- a/src/content/models/gemma4-31b.md
+++ b/src/content/models/gemma4-31b.md
@@ -41,7 +41,7 @@ serving:
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           vllm/vllm-openai:latest \
-          vllm serve nvidia/Gemma-4-31B-IT-NVFP4 \
+          nvidia/Gemma-4-31B-IT-NVFP4 \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \
             --reasoning-parser gemma4 \

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -42,7 +42,7 @@ serving:
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           vllm/vllm-openai:latest \
-          vllm serve google/gemma-4-E2B-it \
+          google/gemma-4-E2B-it \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \
             --reasoning-parser gemma4 \

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -41,7 +41,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
-          ghcr.io/nvidia-ai-iot/vllm:gemma4-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve google/gemma-4-E2B-it \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \

--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -42,7 +42,7 @@ serving:
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           vllm/vllm-openai:latest \
-          vllm serve google/gemma-4-E4B-it \
+          google/gemma-4-E4B-it \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \
             --reasoning-parser gemma4 \

--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -41,7 +41,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
-          ghcr.io/nvidia-ai-iot/vllm:gemma4-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve google/gemma-4-E4B-it \
             --gpu-memory-utilization 0.75 \
             --enable-auto-tool-choice \

--- a/src/content/models/gpt-oss-120b.md
+++ b/src/content/models/gpt-oss-120b.md
@@ -36,7 +36,7 @@ supported_inference_engines:
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         -v $HOME/.cache/tiktoken:/etc/encodings \
         -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.8
 ---
 
@@ -61,7 +61,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   -v $HOME/.cache/huggingface:/root/.cache/huggingface \
   -v $HOME/.cache/tiktoken:/etc/encodings \
   -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm/vllm-openai:latest \
   vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.8
 ```
 

--- a/src/content/models/gpt-oss-120b.md
+++ b/src/content/models/gpt-oss-120b.md
@@ -37,7 +37,7 @@ supported_inference_engines:
         -v $HOME/.cache/tiktoken:/etc/encodings \
         -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
         vllm/vllm-openai:latest \
-        vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.8
+        openai/gpt-oss-120b --gpu-memory-utilization 0.8
 ---
 
 [OpenAI GPT OSS 120B](https://huggingface.co/openai/gpt-oss-120b) is OpenAI's open-source 120 billion parameter language model. Due to its size, this model is exclusively supported on Jetson AGX Thor. It requires tiktoken encodings to be downloaded before serving.
@@ -62,7 +62,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   -v $HOME/.cache/tiktoken:/etc/encodings \
   -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
   vllm/vllm-openai:latest \
-  vllm serve openai/gpt-oss-120b --gpu-memory-utilization 0.8
+  openai/gpt-oss-120b --gpu-memory-utilization 0.8
 ```
 
 ## GPT OSS Family

--- a/src/content/models/gpt-oss-20b.md
+++ b/src/content/models/gpt-oss-20b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
         -v $HOME/.cache/tiktoken:/etc/encodings \
         -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
         vllm/vllm-openai:latest \
-        vllm serve openai/gpt-oss-20b --gpu-memory-utilization 0.8
+        openai/gpt-oss-20b --gpu-memory-utilization 0.8
 benchmark_key: "GPT-OSS-20B"
 ---
 
@@ -90,7 +90,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   -v $HOME/.cache/tiktoken:/etc/encodings \
   -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
   vllm/vllm-openai:latest \
-  vllm serve openai/gpt-oss-20b --gpu-memory-utilization 0.8
+  openai/gpt-oss-20b --gpu-memory-utilization 0.8
 ```
 
 </div>

--- a/src/content/models/gpt-oss-20b.md
+++ b/src/content/models/gpt-oss-20b.md
@@ -44,7 +44,7 @@ supported_inference_engines:
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         -v $HOME/.cache/tiktoken:/etc/encodings \
         -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve openai/gpt-oss-20b --gpu-memory-utilization 0.8
 benchmark_key: "GPT-OSS-20B"
 ---
@@ -89,7 +89,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   -v $HOME/.cache/huggingface:/root/.cache/huggingface \
   -v $HOME/.cache/tiktoken:/etc/encodings \
   -e TIKTOKEN_ENCODINGS_BASE=/etc/encodings \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm/vllm-openai:latest \
   vllm serve openai/gpt-oss-20b --gpu-memory-utilization 0.8
 ```
 

--- a/src/content/models/llama3-1-70b.md
+++ b/src/content/models/llama3-1-70b.md
@@ -53,7 +53,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16
+        RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/llama3-1-70b.md
+++ b/src/content/models/llama3-1-70b.md
@@ -52,7 +52,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/llama3-1-8b.md
+++ b/src/content/models/llama3-1-8b.md
@@ -57,7 +57,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
+        RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/llama3-1-8b.md
+++ b/src/content/models/llama3-1-8b.md
@@ -56,7 +56,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/llama3-2-3b.md
+++ b/src/content/models/llama3-2-3b.md
@@ -57,7 +57,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve espressor/meta-llama.Llama-3.2-3B-Instruct_W4A16
 one_shot_inference:
   modules_supported:

--- a/src/content/models/llama3-2-3b.md
+++ b/src/content/models/llama3-2-3b.md
@@ -58,7 +58,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve espressor/meta-llama.Llama-3.2-3B-Instruct_W4A16
+        espressor/meta-llama.Llama-3.2-3B-Instruct_W4A16
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/ministral3-14b-instruct.md
+++ b/src/content/models/ministral3-14b-instruct.md
@@ -35,7 +35,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-14B-Instruct-2512
+          mistralai/Ministral-3-14B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"
       modules_supported:

--- a/src/content/models/ministral3-14b-instruct.md
+++ b/src/content/models/ministral3-14b-instruct.md
@@ -34,7 +34,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-14B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"

--- a/src/content/models/ministral3-14b-reasoning.md
+++ b/src/content/models/ministral3-14b-reasoning.md
@@ -35,7 +35,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-14B-Reasoning-2512
+          mistralai/Ministral-3-14B-Reasoning-2512
 ---
 
 Mistral AI's Ministral 3 14B Reasoning is the most powerful reasoning variant, excelling at complex logical analysis and problem-solving.

--- a/src/content/models/ministral3-14b-reasoning.md
+++ b/src/content/models/ministral3-14b-reasoning.md
@@ -34,7 +34,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-14B-Reasoning-2512
 ---
 

--- a/src/content/models/ministral3-3b-instruct.md
+++ b/src/content/models/ministral3-3b-instruct.md
@@ -37,7 +37,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-3B-Instruct-2512
+          mistralai/Ministral-3-3B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"
       modules_supported:

--- a/src/content/models/ministral3-3b-instruct.md
+++ b/src/content/models/ministral3-3b-instruct.md
@@ -36,7 +36,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-3B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"

--- a/src/content/models/ministral3-3b-reasoning.md
+++ b/src/content/models/ministral3-3b-reasoning.md
@@ -36,7 +36,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-3B-Reasoning-2512
 ---
 

--- a/src/content/models/ministral3-3b-reasoning.md
+++ b/src/content/models/ministral3-3b-reasoning.md
@@ -37,7 +37,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-3B-Reasoning-2512
+          mistralai/Ministral-3-3B-Reasoning-2512
 ---
 
 Mistral AI's Ministral 3 3B Reasoning is specifically optimized for logical reasoning, problem-solving, and analytical tasks.

--- a/src/content/models/ministral3-8b-instruct.md
+++ b/src/content/models/ministral3-8b-instruct.md
@@ -35,7 +35,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-8B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"

--- a/src/content/models/ministral3-8b-instruct.md
+++ b/src/content/models/ministral3-8b-instruct.md
@@ -36,7 +36,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-8B-Instruct-2512
+          mistralai/Ministral-3-8B-Instruct-2512
     - engine: "Ollama"
       type: "CLI"
       modules_supported:

--- a/src/content/models/ministral3-8b-reasoning.md
+++ b/src/content/models/ministral3-8b-reasoning.md
@@ -35,7 +35,7 @@ serving:
       serve_command_thor: |-
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
-          ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+          vllm/vllm-openai:latest \
           vllm serve mistralai/Ministral-3-8B-Reasoning-2512
 ---
 

--- a/src/content/models/ministral3-8b-reasoning.md
+++ b/src/content/models/ministral3-8b-reasoning.md
@@ -36,7 +36,7 @@ serving:
         sudo docker run -it --rm --pull always \
           --runtime=nvidia --network host \
           vllm/vllm-openai:latest \
-          vllm serve mistralai/Ministral-3-8B-Reasoning-2512
+          mistralai/Ministral-3-8B-Reasoning-2512
 ---
 
 Mistral AI's Ministral 3 8B Reasoning is the default reasoning variant, balancing reasoning capability with efficiency.

--- a/src/content/models/nemotron-3-nano-omni.md
+++ b/src/content/models/nemotron-3-nano-omni.md
@@ -30,7 +30,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         --entrypoint bash \
-        vllm/vllm-openai:v0.20.0-ubuntu2404 \
+        vllm/vllm-openai:latest \
         -c "pip install -q 'vllm[audio]' && vllm serve nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 \
           --trust-remote-code --gpu-memory-utilization 0.8 --max-model-len 32768 \
           --reasoning-parser nemotron_v3 --enable-auto-tool-choice --tool-call-parser qwen3_coder"
@@ -102,7 +102,7 @@ sudo docker run -it --rm --pull always \
   --runtime=nvidia --network host \
   -v $HOME/.cache/huggingface:/root/.cache/huggingface \
   --entrypoint bash \
-  vllm/vllm-openai:v0.20.0-ubuntu2404 \
+  vllm/vllm-openai:latest \
   -c "pip install -q 'vllm[audio]' && vllm serve nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 \
     --trust-remote-code --gpu-memory-utilization 0.8 --max-model-len 32768 \
     --reasoning-parser nemotron_v3 --enable-auto-tool-choice --tool-call-parser qwen3_coder"

--- a/src/content/models/nemotron-3-super.md
+++ b/src/content/models/nemotron-3-super.md
@@ -28,7 +28,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         --entrypoint "" \
-        vllm/vllm-openai:v0.23.0-aarch64-ubuntu2404 \
+        vllm/vllm-openai:latest \
         vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
           --trust-remote-code \
           --kv-cache-dtype fp8 \

--- a/src/content/models/nemotron-nano-12b-vl.md
+++ b/src/content/models/nemotron-nano-12b-vl.md
@@ -28,7 +28,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD
 ---
 

--- a/src/content/models/nemotron-nano-12b-vl.md
+++ b/src/content/models/nemotron-nano-12b-vl.md
@@ -29,7 +29,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD
+        nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD
 ---
 
 NVIDIA Nemotron Nano 12B VL is a vision-language model capable of understanding images and text, with support for chain-of-thought reasoning across multimodal inputs.

--- a/src/content/models/nemotron-nano-9b-v2.md
+++ b/src/content/models/nemotron-nano-9b-v2.md
@@ -28,7 +28,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4
 benchmark_key: "Nemotron Nano 9B V2"
 benchmark_series:

--- a/src/content/models/nemotron-nano-9b-v2.md
+++ b/src/content/models/nemotron-nano-9b-v2.md
@@ -29,7 +29,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4
+        nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4
 benchmark_key: "Nemotron Nano 9B V2"
 benchmark_series:
   - "Nemotron 3 30B-A3B"

--- a/src/content/models/qwen3-30b-a3b.md
+++ b/src/content/models/qwen3-30b-a3b.md
@@ -43,7 +43,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Qwen3-30B-A3B-quantized.w4a16
 benchmark_key: "Qwen3-30B-A3B"
 benchmark_series:

--- a/src/content/models/qwen3-30b-a3b.md
+++ b/src/content/models/qwen3-30b-a3b.md
@@ -44,7 +44,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Qwen3-30B-A3B-quantized.w4a16
+        RedHatAI/Qwen3-30B-A3B-quantized.w4a16
 benchmark_key: "Qwen3-30B-A3B"
 benchmark_series:
   - "Qwen3-32B"

--- a/src/content/models/qwen3-32b.md
+++ b/src/content/models/qwen3-32b.md
@@ -43,7 +43,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Qwen3-32B-quantized.w4a16
+        RedHatAI/Qwen3-32B-quantized.w4a16
 benchmark_key: "Qwen3-32B"
 benchmark_series:
   - "Qwen3-30B-A3B"

--- a/src/content/models/qwen3-32b.md
+++ b/src/content/models/qwen3-32b.md
@@ -42,7 +42,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Qwen3-32B-quantized.w4a16
 benchmark_key: "Qwen3-32B"
 benchmark_series:

--- a/src/content/models/qwen3-4b.md
+++ b/src/content/models/qwen3-4b.md
@@ -46,7 +46,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Qwen3-4B-quantized.w4a16
+        RedHatAI/Qwen3-4B-quantized.w4a16
 benchmark_key: "Qwen 3 4B"
 benchmark_series:
   - "Qwen 3 8B"

--- a/src/content/models/qwen3-4b.md
+++ b/src/content/models/qwen3-4b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Qwen3-4B-quantized.w4a16
 benchmark_key: "Qwen 3 4B"
 benchmark_series:

--- a/src/content/models/qwen3-5-0-8b.md
+++ b/src/content/models/qwen3-5-0-8b.md
@@ -41,7 +41,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve Qwen/Qwen3.5-0.8B \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \

--- a/src/content/models/qwen3-5-0-8b.md
+++ b/src/content/models/qwen3-5-0-8b.md
@@ -42,7 +42,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve Qwen/Qwen3.5-0.8B \
+        Qwen/Qwen3.5-0.8B \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-5-27b.md
+++ b/src/content/models/qwen3-5-27b.md
@@ -39,7 +39,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve Kbenkhaled/Qwen3.5-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
@@ -99,7 +99,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm/vllm-openai:latest \
   vllm serve Kbenkhaled/Qwen3.5-27B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-5-27b.md
+++ b/src/content/models/qwen3-5-27b.md
@@ -40,7 +40,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve Kbenkhaled/Qwen3.5-27B-NVFP4 \
+        Kbenkhaled/Qwen3.5-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
@@ -100,7 +100,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   vllm/vllm-openai:latest \
-  vllm serve Kbenkhaled/Qwen3.5-27B-NVFP4 \
+  Kbenkhaled/Qwen3.5-27B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \
     --enable-auto-tool-choice --tool-call-parser qwen3_coder

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -39,7 +39,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
@@ -99,7 +99,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm/vllm-openai:latest \
   vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -40,7 +40,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
+        AxionML/Qwen3.5-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
@@ -100,7 +100,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   vllm/vllm-openai:latest \
-  vllm serve AxionML/Qwen3.5-35B-A3B-NVFP4 \
+  AxionML/Qwen3.5-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \
     --enable-auto-tool-choice --tool-call-parser qwen3_coder

--- a/src/content/models/qwen3-5-4b.md
+++ b/src/content/models/qwen3-5-4b.md
@@ -41,7 +41,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve cyankiwi/Qwen3.5-4B-AWQ-4bit \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \

--- a/src/content/models/qwen3-5-4b.md
+++ b/src/content/models/qwen3-5-4b.md
@@ -42,7 +42,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve cyankiwi/Qwen3.5-4B-AWQ-4bit \
+        cyankiwi/Qwen3.5-4B-AWQ-4bit \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-5-9b.md
+++ b/src/content/models/qwen3-5-9b.md
@@ -41,7 +41,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve AxionML/Qwen3.5-9B-NVFP4 \
+        AxionML/Qwen3.5-9B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-5-9b.md
+++ b/src/content/models/qwen3-5-9b.md
@@ -40,7 +40,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve AxionML/Qwen3.5-9B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -23,7 +23,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        vllm/vllm-openai:nightly-aarch64 \
+        vllm/vllm-openai:latest \
         bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
@@ -58,7 +58,7 @@ Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  vllm/vllm-openai:nightly-aarch64 \
+  vllm/vllm-openai:latest \
   bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -23,6 +23,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
+        --entrypoint "" \
         vllm/vllm-openai:latest \
         bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
@@ -58,6 +59,7 @@ Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  --entrypoint "" \
   vllm/vllm-openai:latest \
   bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -25,7 +25,7 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         --entrypoint "" \
         vllm/vllm-openai:latest \
-        bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
+        bash -c "pip install -q 'vllm[audio]' && exec vllm serve nvidia/Qwen3.6-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
@@ -58,13 +58,16 @@ Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 
 ## Running with vLLM
 
 ```bash
-sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+sudo docker run -it --rm --pull always \
+  --runtime=nvidia --network host \
   --entrypoint "" \
   vllm/vllm-openai:latest \
-  bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
-    --gpu-memory-utilization 0.8 --enable-prefix-caching \
+  bash -c "pip install -q 'vllm[audio]' && exec vllm serve nvidia/Qwen3.6-27B-NVFP4 \
+    --gpu-memory-utilization 0.8 \
+    --enable-prefix-caching \
     --reasoning-parser qwen3 \
-    --enable-auto-tool-choice --tool-call-parser qwen3_coder"
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder"
 ```
 
 ## Speculative Decoding with MTP
@@ -85,4 +88,4 @@ This model supports **Multi-Token Prediction (MTP)** speculative decoding, which
 ## Additional Resources
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-27B) - Original model weights
-- [NVFP4 Checkpoint (Thor)](https://huggingface.co/sakamakismile/Qwen3.6-27B-NVFP4) - Quantized for Jetson Thor
+- [NVFP4 Checkpoint (Thor)](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4) - Quantized for Jetson Thor

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -35,6 +35,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
+        --entrypoint "" \
         vllm/vllm-openai:latest \
         bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
@@ -94,6 +95,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  --entrypoint "" \
   vllm/vllm-openai:latest \
   bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -35,7 +35,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        vllm/vllm-openai:nightly-aarch64 \
+        vllm/vllm-openai:latest \
         bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
@@ -94,7 +94,7 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  vllm/vllm-openai:nightly-aarch64 \
+  vllm/vllm-openai:latest \
   bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \

--- a/src/content/models/qwen3-8b.md
+++ b/src/content/models/qwen3-8b.md
@@ -45,7 +45,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve RedHatAI/Qwen3-8B-quantized.w4a16
+        RedHatAI/Qwen3-8B-quantized.w4a16
 benchmark_key: "Qwen 3 8B"
 benchmark_series:
   - "Qwen 3 4B"

--- a/src/content/models/qwen3-8b.md
+++ b/src/content/models/qwen3-8b.md
@@ -44,7 +44,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve RedHatAI/Qwen3-8B-quantized.w4a16
 benchmark_key: "Qwen 3 8B"
 benchmark_series:

--- a/src/content/models/qwen3-vl-4b.md
+++ b/src/content/models/qwen3-vl-4b.md
@@ -36,7 +36,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit
+        cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit
 benchmark_key: "Qwen3-VL-4B"
 benchmark_series:
   - "Qwen3-VL-8B"

--- a/src/content/models/qwen3-vl-4b.md
+++ b/src/content/models/qwen3-vl-4b.md
@@ -35,7 +35,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit
 benchmark_key: "Qwen3-VL-4B"
 benchmark_series:

--- a/src/content/models/qwen3-vl-8b.md
+++ b/src/content/models/qwen3-vl-8b.md
@@ -35,7 +35,7 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
-        vllm serve cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit
+        cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit
 benchmark_key: "Qwen3-VL-8B"
 benchmark_series:
   - "Qwen3-VL-4B"

--- a/src/content/models/qwen3-vl-8b.md
+++ b/src/content/models/qwen3-vl-8b.md
@@ -34,7 +34,7 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm/vllm-openai:latest \
         vllm serve cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit
 benchmark_key: "Qwen3-VL-8B"
 benchmark_series:


### PR DESCRIPTION
Updated all Jetson Thor (T5000 / T4000) vLLM serve commands to vllm/vllm-openai:latest across 42 model pages (frontmatter serve_command_thor and the Thor code blocks in page bodies), covering every variant:

ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor → vllm/vllm-openai:latest (32 files)
ghcr.io/nvidia-ai-iot/vllm:gemma4-jetson-thor → vllm/vllm-openai:latest (gemma4-12b/26b/31b/e2b/e4b)
vllm/vllm-openai:nightly-aarch64 / :v0.20.0… / :v0.23.0… / :v0.24.0… → :latest
pinned vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 (cosmos-reason2) → :latest
