### PR TITLE
TensorRT Edge-LLM 0.10.0 Integration into Jetson AI Lab

### DIFF
--- a/public/code-samples/tensorrt_edge_llm/run_model.sh
+++ b/public/code-samples/tensorrt_edge_llm/run_model.sh
@@ -1,0 +1,2661 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the public entry point as a shell script while using Python for JSON,
+# checkpoint metadata, and argument-safe subprocess orchestration.
+exec python3 - "$@" <<'PY'
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_VERSION = "0.10.0"
+
+VLM_MODEL_TYPES = {
+    "qwen2_vl",
+    "qwen3_vl",
+    "qwen3_omni",
+    "qwen3_omni_thinker",
+    "qwen3_omni_moe",
+    "qwen3_omni_moe_thinker",
+    "qwen3_omni_next",
+    "qwen3_omni_next_thinker",
+    "qwen3_5",
+    "qwen3_5_moe",
+    "qwen2_5_vl",
+    "internvl",
+    "internvl_chat",
+    "phi4mm",
+    "phi4_multimodal",
+    "gemma4",
+    "gemma4_text",
+    "gemma4_unified",
+    "gemma4_unified_text",
+    "alpamayo_r1",
+    "NemotronH_Nano_VL_V2",
+    "NemotronH_Nano_Omni_Reasoning_V3",
+    "cosmos3_edge",
+    "diffusion_gemma",
+}
+
+AUDIO_MODEL_TYPES = {
+    "gemma4",
+    "gemma4_text",
+    "gemma4_unified",
+    "gemma4_unified_text",
+    "qwen3_asr",
+    "qwen3_omni",
+    "qwen3_omni_thinker",
+    "qwen3_omni_moe",
+    "qwen3_omni_moe_thinker",
+    "qwen3_omni_next",
+    "qwen3_omni_next_thinker",
+    "NemotronH_Nano_Omni_Reasoning_V3",
+}
+
+OMNI_MODEL_TYPES = {
+    "qwen3_omni",
+    "qwen3_omni_moe",
+    "qwen3_omni_next",
+}
+
+WEIGHTLESS_EXTERNAL_WEIGHT_KINDS = (
+    "int4_ffn",
+    "int4_moe",
+    "nvfp4_moe",
+    "lm_head",
+    "fp16",
+    "embedding",
+)
+
+PLE_MODEL_TYPES = {
+    "gemma4",
+    "gemma4_text",
+    "gemma4_unified",
+    "gemma4_unified_text",
+}
+
+@dataclass(frozen=True)
+class ModelInfo:
+    path: Path
+    model_type: str
+    has_llm: bool
+    has_visual: bool
+    has_audio: bool
+    has_talker: bool
+    has_code_predictor: bool
+    has_code2wav: bool
+    has_action: bool
+    is_tts: bool
+    tts_mode: str
+    is_omni: bool
+    is_moe: bool
+    is_diffusion: bool
+    is_cosmos3: bool
+    is_cosmos3_policy: bool
+    is_nemotron_asr: bool
+    external_weights: tuple[str, ...]
+
+
+def default_workspace() -> Path:
+    data = Path("/data/edgellm")
+    if data.parent.exists() and os.access(data.parent, os.W_OK):
+        return data
+    return Path.cwd() / "edgellm-workspace"
+
+
+def find_edgellm_home(value: str) -> Path:
+    candidates = []
+    if value:
+        candidates.append(Path(value))
+    if os.environ.get("EDGELLM_HOME"):
+        candidates.append(Path(os.environ["EDGELLM_HOME"]))
+    candidates.extend((Path.cwd(), Path("/opt/TensorRT-Edge-LLM")))
+    for candidate in candidates:
+        if (candidate / "tensorrt_edgellm").is_dir() and (candidate / "CMakeLists.txt").is_file():
+            return candidate.resolve()
+    raise SystemExit("TensorRT Edge-LLM source was not found; pass --edgellm-home.")
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="run_model.sh",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""Build, run, and benchmark one TensorRT Edge-LLM 0.10.0 checkpoint.
+
+The default weightless builder skips ONNX and builds checkpoint-backed engines
+for every registered component. Select --builder onnx for serving or the
+supported ONNX workflow. Speculative decoding is never enabled implicitly.
+""",
+    )
+    p.add_argument("model", help="Hugging Face model ID or local checkpoint directory")
+    p.add_argument("--stage", choices=("all", "export", "build", "infer", "bench", "serve"), default="all")
+    p.add_argument(
+        "--builder",
+        choices=("weightless", "onnx", "direct"),
+        default="weightless",
+        help=(
+            "Engine frontend. 'weightless' is the experimental checkpoint-backed "
+            "ONNX-less 0.10 builder; 'direct' is retained as an alias."
+        ),
+    )
+    p.add_argument("--workspace", type=Path, default=default_workspace())
+    p.add_argument("--edgellm-home", default="")
+    p.add_argument("--revision", default=None, help="Hugging Face revision")
+    p.add_argument("--local-files-only", action="store_true")
+
+    spec = p.add_mutually_exclusive_group()
+    spec.add_argument("--mtp", action="store_const", const="mtp", dest="spec_mode")
+    spec.add_argument("--eagle3", metavar="DRAFT", dest="eagle3_draft")
+    spec.add_argument("--dflash", metavar="DRAFT", dest="dflash_draft")
+    spec.add_argument("--dspark", metavar="DRAFT", dest="dspark_draft")
+    p.set_defaults(spec_mode="none")
+    p.add_argument("--mtp-draft", default="", help="Matched Gemma4 MTP assistant checkpoint")
+    p.add_argument("--draft-top-k", type=int)
+    p.add_argument("--draft-steps", type=int)
+    p.add_argument("--verify-size", type=int)
+    p.add_argument("--dflash-block-size", type=int, default=0)
+    p.add_argument("--diffusion-steps", type=int, default=16)
+    p.add_argument("--policy-steps", type=int, default=4)
+    p.add_argument("--policy-seed", type=int, default=0)
+    p.add_argument("--policy-domain", default="droid_lerobot")
+    p.add_argument("--policy-viewpoint", default="ego_view")
+    p.add_argument("--policy-guidance", type=float, default=1.0)
+    p.add_argument("--policy-video-subsample-factor", type=int, default=1)
+    p.add_argument("--policy-action-chunk-size", type=int, default=0)
+    p.add_argument("--asr-prompt-id", type=int)
+
+    p.add_argument("--omni-root-model", default="", help="Original full Qwen3-Omni checkpoint for split NVFP4 export")
+    p.add_argument("--talker-model", default="", help="Split Qwen3-Omni Talker checkpoint")
+
+    p.add_argument("--input-json", type=Path, help="Existing Edge-LLM request JSON; passed through unchanged")
+    p.add_argument("--prompt", action="append", default=[])
+    p.add_argument("--system-prompt", default="")
+    p.add_argument("--image", action="append", default=[], type=Path)
+    p.add_argument("--audio", action="append", default=[], type=Path)
+    p.add_argument("--video-frame", action="append", default=[], type=Path)
+    p.add_argument("--video-fps", type=float, default=1.0)
+    p.add_argument("--trajectory", default="", help="Trajectory JSON array or path to a JSON file")
+    p.add_argument("--speaker", default="ryan")
+    p.add_argument("--language", default="auto", help="Qwen3-TTS language conditioning")
+    p.add_argument("--tts-instruct", default="", help="Qwen3-TTS style or VoiceDesign instruction")
+    p.add_argument("--ref-audio", type=Path, help="Qwen3-TTS Base voice-clone reference audio")
+    p.add_argument("--ref-text", default="", help="Exact transcript for Qwen3-TTS Base ICL voice cloning")
+    p.add_argument("--text-only", action="store_true", help="Do not add bundled media to the default smoke request")
+    p.add_argument("--audio-output", action="store_true", help="Generate speech output for Qwen3-Omni")
+    thinking = p.add_mutually_exclusive_group()
+    thinking.add_argument("--enable-thinking", action="store_true", dest="enable_thinking")
+    thinking.add_argument("--disable-thinking", action="store_false", dest="enable_thinking")
+    p.set_defaults(enable_thinking=None)
+
+    p.add_argument("--batch-size", type=int, default=1, help="Offline request and benchmark batch size")
+    p.add_argument("--max-batch-size", type=int, help="Engine profile batch size")
+    p.add_argument("--max-input-len", type=int)
+    p.add_argument("--max-kv-cache-capacity", type=int)
+    p.add_argument("--max-generate-length", type=int, default=128)
+    p.add_argument("--temperature", type=float, default=1.0)
+    p.add_argument("--top-p", type=float, default=1.0)
+    p.add_argument("--top-k", type=int, default=50)
+
+    p.add_argument("--min-image-tokens", type=int)
+    p.add_argument("--max-image-tokens", type=int)
+    p.add_argument("--max-image-tokens-per-image", type=int)
+    p.add_argument("--min-audio-time-steps", type=int, default=100)
+    p.add_argument("--max-audio-time-steps", type=int, default=6000)
+    p.add_argument("--max-code-length", type=int, default=2000)
+
+    p.add_argument("--inference-warmup", type=int, default=10)
+    p.add_argument("--bench-warmup", type=int, default=3)
+    p.add_argument("--bench-iterations", type=int, default=10)
+    p.add_argument("--prefill-len", type=int, help="Prefill benchmark length (default: up to 2048 within the engine profile)")
+    p.add_argument("--past-kv-len", type=int, help="Decode benchmark prefix length (default: up to 2048 within KV capacity)")
+    p.add_argument("--bench-output-len", type=int, default=128)
+    p.add_argument("--image-size", default="1024x2048")
+
+    p.add_argument("--output-json", type=Path)
+    p.add_argument("--profile-json", type=Path)
+    p.add_argument("--host", default="0.0.0.0")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument(
+        "--allowed-local-media-path",
+        default="",
+        help=(
+            "Directory the HTTP server may read image, audio, or video files "
+            "from. Local media is disabled unless this is set."
+        ),
+    )
+
+    p.add_argument(
+        "--externalize-weight", action="append", default=[],
+        choices=("int4_ffn", "int4_moe", "nvfp4_moe", "lm_head"),
+        help=(
+            "Explicit external-weight subset. Omit it for the weightless "
+            "builder's maximum checkpoint-backed policy."
+        ),
+    )
+    p.add_argument("--export-arg", action="append", default=[], help="One extra exporter token; use --export-arg=--flag")
+    p.add_argument(
+        "--weightless-build-arg", "--direct-build-arg",
+        action="append", default=[], dest="weightless_build_arg",
+        help="One extra tensorrt-edgellm-build token",
+    )
+    p.add_argument("--llm-build-arg", action="append", default=[], help="One extra token for every llm_build command")
+    p.add_argument("--talker-build-arg", action="append", default=[])
+    p.add_argument("--code-predictor-build-arg", action="append", default=[])
+    p.add_argument("--visual-build-arg", action="append", default=[])
+    p.add_argument("--audio-build-arg", action="append", default=[])
+    p.add_argument("--action-build-arg", action="append", default=[])
+    p.add_argument("--inference-arg", action="append", default=[])
+    p.add_argument(
+        "--bench-arg",
+        action="append",
+        default=[],
+        help="One extra llm_bench token; --profile adds a separate layer-profile pass",
+    )
+
+    p.add_argument("--force-export", action="store_true")
+    p.add_argument("--force-build", action="store_true")
+    p.add_argument("--no-inference", action="store_true")
+    p.add_argument("--no-benchmark", action="store_true")
+    p.add_argument("--skip-software-build", action="store_true")
+    p.add_argument("--dry-run", action="store_true", help="Print and record commands without executing them")
+    return p
+
+
+def check_positive(name: str, value: int | None, allow_zero: bool = False) -> None:
+    if value is None:
+        return
+    minimum = 0 if allow_zero else 1
+    if value < minimum:
+        raise SystemExit(f"{name} must be >= {minimum}, got {value}")
+
+
+def system_memory_gib() -> float:
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) / (1024 * 1024)
+    except (OSError, ValueError, IndexError):
+        pass
+    return 0.0
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    for name in (
+        "batch_size", "max_batch_size", "max_input_len", "max_kv_cache_capacity",
+        "max_generate_length", "draft_top_k", "draft_steps", "verify_size",
+        "min_image_tokens", "max_image_tokens", "max_image_tokens_per_image",
+        "min_audio_time_steps", "max_audio_time_steps", "max_code_length",
+        "bench_iterations", "prefill_len", "past_kv_len", "bench_output_len",
+        "diffusion_steps",
+        "policy_steps", "policy_video_subsample_factor",
+    ):
+        check_positive("--" + name.replace("_", "-"), getattr(args, name))
+    check_positive("--dflash-block-size", args.dflash_block_size, allow_zero=True)
+    check_positive("--inference-warmup", args.inference_warmup, allow_zero=True)
+    check_positive("--bench-warmup", args.bench_warmup, allow_zero=True)
+    check_positive("--policy-seed", args.policy_seed, allow_zero=True)
+    check_positive("--policy-action-chunk-size", args.policy_action_chunk_size, allow_zero=True)
+    check_positive("--asr-prompt-id", args.asr_prompt_id, allow_zero=True)
+    if args.policy_guidance <= 0:
+        raise SystemExit("--policy-guidance must be positive")
+    if args.video_fps <= 0:
+        raise SystemExit("--video-fps must be positive")
+    if args.port < 1 or args.port > 65535:
+        raise SystemExit("--port must be between 1 and 65535")
+    if not re.fullmatch(r"[1-9][0-9]*x[1-9][0-9]*", args.image_size):
+        raise SystemExit("--image-size must use positive HxW dimensions, for example 896x448")
+    if args.input_json and any((
+        args.prompt, args.system_prompt, args.image, args.audio, args.video_frame,
+        args.trajectory, args.tts_instruct, args.ref_audio, args.ref_text,
+        args.language != "auto",
+    )):
+        raise SystemExit("--input-json cannot be combined with prompt/media request-generation options")
+    if args.ref_text and not args.ref_audio:
+        raise SystemExit("--ref-text requires --ref-audio")
+    if bool(args.omni_root_model) != bool(args.talker_model):
+        raise SystemExit("--omni-root-model and --talker-model must be provided together")
+    if args.eagle3_draft:
+        args.spec_mode = "eagle3"
+        args.draft_model = args.eagle3_draft
+    elif args.dflash_draft:
+        args.spec_mode = "dflash"
+        args.draft_model = args.dflash_draft
+    elif args.dspark_draft:
+        args.spec_mode = "dspark"
+        args.draft_model = args.dspark_draft
+    else:
+        args.draft_model = args.mtp_draft
+    if args.spec_mode != "mtp" and args.mtp_draft:
+        raise SystemExit("--mtp-draft requires --mtp")
+    if args.spec_mode != "none" and args.omni_root_model:
+        raise SystemExit("Split Qwen3-Omni export is not supported with speculative decoding")
+    if args.builder == "weightless" and args.stage == "export":
+        raise SystemExit("--stage export is not part of the weightless builder; use --stage build or all")
+    if args.builder == "weightless" and args.stage == "serve":
+        raise SystemExit(
+            "TensorRT Edge-LLM 0.10.0 serving does not accept checkpoint-backed "
+            "weightless engines; use --builder onnx for --stage serve"
+        )
+    if any(token == "--externalize-weights" for token in args.export_arg):
+        raise SystemExit("Use --externalize-weight; automatic INT4/NVFP4 externalization must remain enabled")
+
+
+def materialized_checkpoint_path(source: Path, root: Path, label: str) -> Path:
+    return root / f"{safe_name(label)}-{short_hash(str(source), 8)}"
+
+
+def materialize_checkpoint(source: Path, destination: Path) -> Path:
+    marker = destination / ".edgellm-source.json"
+    signature = {"source": str(source)}
+    if marker.is_file() and load_json(marker) == signature:
+        print(f"Reusing materialized checkpoint: {destination}", flush=True)
+        return destination
+
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    shutil.rmtree(temporary, ignore_errors=True)
+    temporary.mkdir(parents=True)
+    linked = copied = 0
+    try:
+        for item in source.rglob("*"):
+            relative = item.relative_to(source)
+            target = temporary / relative
+            if item.is_dir() and not item.is_symlink():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            resolved = item.resolve(strict=True)
+            if not resolved.is_file():
+                raise SystemExit(f"Checkpoint entry is not a regular file: {item}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.link(resolved, target)
+                linked += 1
+            except OSError:
+                shutil.copy2(resolved, target)
+                copied += 1
+        (temporary / marker.name).write_text(
+            json.dumps(signature, indent=2) + "\n", encoding="utf-8"
+        )
+        if destination.exists():
+            shutil.rmtree(destination)
+        os.replace(temporary, destination)
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+    print(
+        f"Materialized checkpoint with {linked} hard links and {copied} copies: {destination}",
+        flush=True,
+    )
+    return destination
+
+
+def resolve_checkpoint(
+    model: str,
+    revision: str | None,
+    local_only: bool,
+    metadata_only: bool = False,
+    materialize_root: Path | None = None,
+    materialize: bool = False,
+) -> Path:
+    local = Path(model).expanduser()
+    if local.is_dir():
+        source = local.resolve()
+    else:
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise SystemExit("huggingface_hub is required to resolve Hugging Face model IDs") from exc
+        print(f"Resolving Hugging Face checkpoint: {model}", flush=True)
+        options: dict[str, Any] = {}
+        if metadata_only:
+            options["allow_patterns"] = ["*.json"]
+        source = Path(snapshot_download(
+            repo_id=model,
+            revision=revision,
+            local_files_only=local_only,
+            **options,
+        )).resolve()
+
+    if materialize_root is None:
+        return source
+    if source.parent.name == "snapshots":
+        materialize_root = source.parent.parent / "materialized"
+    destination = materialized_checkpoint_path(source, materialize_root, model)
+    if materialize:
+        materialize_root.mkdir(parents=True, exist_ok=True)
+        return materialize_checkpoint(source, destination)
+    marker = destination / ".edgellm-source.json"
+    if marker.is_file() and load_json(marker) == {"source": str(source)}:
+        return destination
+    return source
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Failed to read JSON {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"Expected a JSON object in {path}")
+    return data
+
+
+def walk_values(value: Any):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key).lower()
+            yield from walk_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_values(child)
+    else:
+        yield str(value).lower()
+
+
+def normalize_tokenizers(root: Path) -> None:
+    """Keep special tokens out of the regular decoder vocabulary."""
+    for path in sorted(root.rglob("tokenizer.json")):
+        data = load_json(path)
+        model = data.get("model")
+        added = data.get("added_tokens")
+        if not isinstance(model, dict) or not isinstance(added, list):
+            continue
+        vocab = model.get("vocab")
+        if not isinstance(vocab, dict):
+            continue
+
+        duplicates = []
+        for token in added:
+            if not isinstance(token, dict) or token.get("special") is not True:
+                continue
+            content = token.get("content")
+            token_id = token.get("id")
+            if isinstance(content, str) and vocab.get(content) == token_id:
+                duplicates.append(content)
+        if not duplicates:
+            continue
+
+        for content in duplicates:
+            del vocab[content]
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        temporary.unlink(missing_ok=True)
+        try:
+            temporary.write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+            os.replace(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+        print(
+            f"Normalized {len(duplicates)} duplicated special tokens in {path}",
+            flush=True,
+        )
+
+
+def ensure_processed_chat_template(source: Path, target: Path) -> None:
+    """Create the C++ tokenizer artifact omitted by direct component builds."""
+    output = target / "processed_chat_template.json"
+    if output.is_file():
+        return
+    if not source.is_dir():
+        raise SystemExit(f"Tokenizer source directory does not exist: {source}")
+
+    from tensorrt_edgellm.chat_template import (
+        process_chat_template,
+        write_fallback_processed_chat_template,
+    )
+
+    target.mkdir(parents=True, exist_ok=True)
+    process_chat_template(str(source), str(target))
+    if not output.is_file():
+        write_fallback_processed_chat_template(str(source), str(target))
+    if not output.is_file():
+        raise SystemExit(f"Failed to create C++ chat template artifact: {output}")
+    print(f"Created C++ chat template artifact: {output}", flush=True)
+
+
+MODEL_CHANNEL_PREFIX = re.compile(
+    r"^(?:(?:thought|final)[ \t]*\r?\n)+", re.IGNORECASE
+)
+
+
+def normalize_model_channel(text: str) -> str:
+    """Remove a decoded Gemma4 channel label while preserving response text."""
+    return MODEL_CHANNEL_PREFIX.sub("", text, count=1)
+
+
+def normalize_gemma4_output(path: Path, raw_path: Path, model_type: str) -> Path | None:
+    """Keep the raw output and expose the provider's response content."""
+    if model_type not in PLE_MODEL_TYPES or not path.is_file():
+        return None
+
+    output = load_json(path)
+    responses = output.get("responses") if isinstance(output, dict) else None
+    if not isinstance(responses, list):
+        return None
+
+    changed = 0
+    for response in responses:
+        if not isinstance(response, dict) or not isinstance(response.get("output_text"), str):
+            continue
+        original = response["output_text"]
+        response["output_text"] = normalize_model_channel(original)
+        changed += response["output_text"] != original
+    if not changed:
+        return None
+
+    shutil.copy2(path, raw_path)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.unlink(missing_ok=True)
+    try:
+        temporary.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    print(
+        f"Normalized {changed} Gemma4 channel label(s); raw output: {raw_path}",
+        flush=True,
+    )
+    return raw_path
+
+
+def gemma4_server_launcher(model_root: Path) -> Path:
+    """Write the server adapter for Gemma4 channel-labelled output."""
+    path = model_root / "checkpoint-compat" / "gemma4_server.py"
+    content = '''#!/usr/bin/env python3
+import json
+import re
+import sys
+
+from experimental.server import LLM
+
+
+PREFIX = re.compile(r"^(?:(?:thought|final)[ \\t]*\\r?\\n)+", re.IGNORECASE)
+STREAM_PREFIXES = ("thought\\n", "final\\n", "thought\\r\\n", "final\\r\\n")
+
+
+def normalize(text):
+    return PREFIX.sub("", text, count=1)
+
+
+class Response:
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    @property
+    def output_texts(self):
+        return [normalize(text) for text in self._wrapped.output_texts]
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+class Runtime:
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def handle_request(self, request):
+        return Response(self._wrapped.handle_request(request))
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+original_generate_stream = LLM.generate_stream
+
+
+def generate_stream(self, *args, **kwargs):
+    pending = ""
+    held_ids = []
+    held_logprobs = []
+    undecided = True
+    for delta in original_generate_stream(self, *args, **kwargs):
+        if not undecided:
+            if held_ids:
+                delta.token_ids = held_ids + list(delta.token_ids)
+                delta.logprobs = held_logprobs + list(delta.logprobs)
+                held_ids = []
+                held_logprobs = []
+            yield delta
+            continue
+
+        pending += delta.text
+        held_ids.extend(delta.token_ids)
+        held_logprobs.extend(delta.logprobs)
+        while True:
+            lowered = pending.lower()
+            if not delta.finished and any(
+                prefix.startswith(lowered) for prefix in STREAM_PREFIXES
+            ):
+                break
+            matched = next(
+                (prefix for prefix in STREAM_PREFIXES if lowered.startswith(prefix)),
+                None,
+            )
+            if matched is None:
+                break
+            pending = pending[len(matched):]
+        lowered = pending.lower()
+        if not delta.finished and any(prefix.startswith(lowered) for prefix in STREAM_PREFIXES):
+            continue
+
+        visible = pending
+        undecided = False
+        delta.text = visible
+        delta.token_ids = held_ids
+        delta.logprobs = held_logprobs
+        held_ids = []
+        held_logprobs = []
+        if delta.text or delta.finished:
+            yield delta
+
+
+LLM.generate_stream = generate_stream
+options = json.loads(sys.argv[1])
+llm = LLM(**options)
+llm._runtime = Runtime(llm._runtime)
+serve_options = json.loads(sys.argv[2])
+llm.serve(**serve_options)
+'''
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.is_file() or path.read_text(encoding="utf-8") != content:
+        path.write_text(content, encoding="utf-8")
+    return path
+
+
+def prepare_gemma4_checkpoint(path: Path, model_root: Path, model_type: str) -> tuple[Path, tuple[str, ...]]:
+    """Create a non-mutating view for incomplete community Gemma4 metadata."""
+    if model_type not in PLE_MODEL_TYPES:
+        return path, ()
+
+    replacements: dict[str, dict[str, Any]] = {}
+    compatibility: list[str] = []
+    for name in ("config.json", "hf_quant_config.json", "quantization_config.json", "quant_cfg.json"):
+        source = path / name
+        if not source.is_file():
+            continue
+        data = load_json(source)
+        changed = False
+        vision = data.get("vision_config")
+        if (
+            name == "config.json"
+            and model_type == "gemma4_unified"
+            and isinstance(vision, dict)
+            and "model_patch_size" not in vision
+        ):
+            patch_size = vision.get("patch_size")
+            pooling_kernel_size = vision.get("pooling_kernel_size")
+            if not isinstance(patch_size, int) or not isinstance(pooling_kernel_size, int):
+                raise SystemExit(
+                    "Gemma4 Unified vision_config must define integer patch_size and "
+                    "pooling_kernel_size"
+                )
+            vision["model_patch_size"] = patch_size * pooling_kernel_size
+            changed = True
+            compatibility.append("unified_model_patch_size")
+
+        audio = data.get("audio_config")
+        if (
+            name == "config.json"
+            and model_type == "gemma4_unified"
+            and isinstance(audio, dict)
+            and "output_proj_dims" not in audio
+        ):
+            output_proj_dims = audio.get("audio_embed_dim", audio.get("hidden_size"))
+            if not isinstance(output_proj_dims, int):
+                raise SystemExit(
+                    "Gemma4 Unified audio_config must define integer audio_embed_dim "
+                    "or hidden_size"
+                )
+            audio["output_proj_dims"] = output_proj_dims
+            changed = True
+            compatibility.append("unified_audio_output_proj_dims")
+        if changed:
+            replacements[name] = data
+
+    if not replacements and not compatibility:
+        return path, ()
+
+    signature = {
+        "source": str(path),
+        "compatibility": compatibility,
+        "sidecars": {
+            name: hashlib.sha256(
+                json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()
+            for name, data in replacements.items()
+        },
+    }
+    view = model_root / "checkpoint-compat" / f"gemma4-{short_hash(signature, 8)}"
+    marker = view / ".edgellm-compat.json"
+    if marker.is_file() and load_json(marker) == signature:
+        print(f"Using Gemma4 compatibility view: {view}", flush=True)
+        return view, tuple(compatibility)
+
+    temporary = view.with_name(f".{view.name}.{os.getpid()}.tmp")
+    shutil.rmtree(temporary, ignore_errors=True)
+    temporary.mkdir(parents=True)
+    try:
+        for source in path.iterdir():
+            destination = temporary / source.name
+            if source.name in replacements:
+                destination.write_text(
+                    json.dumps(replacements[source.name], indent=2) + "\n",
+                    encoding="utf-8",
+                )
+            else:
+                os.symlink(source.resolve(), destination, target_is_directory=source.is_dir())
+        marker = temporary / marker.name
+        marker.write_text(json.dumps(signature, indent=2) + "\n", encoding="utf-8")
+        shutil.rmtree(view, ignore_errors=True)
+        os.replace(temporary, view)
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+
+    print(
+        "Prepared TensorRT Edge-LLM Gemma4 compatibility view "
+        f"({', '.join(compatibility)}): {view}",
+        flush=True,
+    )
+    return view, tuple(compatibility)
+
+
+def has_moe_experts(value: Any) -> bool:
+    moe_keys = {"num_experts", "num_local_experts", "n_routed_experts", "moe_intermediate_size"}
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).lower() in moe_keys:
+                try:
+                    if int(child) > 0:
+                        return True
+                except (TypeError, ValueError):
+                    pass
+            if has_moe_experts(child):
+                return True
+    elif isinstance(value, list):
+        return any(has_moe_experts(child) for child in value)
+    return False
+
+
+def checkpoint_uses_fp8_kv_cache(path: Path) -> bool:
+    """Return whether checkpoint metadata requests an FP8 KV cache."""
+
+    def kv_metadata_is_fp8(value: Any, kv_context: bool = False) -> bool:
+        if isinstance(value, dict):
+            if kv_context:
+                kind = str(value.get("type", "")).lower()
+                try:
+                    if kind == "float" and int(value.get("num_bits", 0)) == 8:
+                        return True
+                except (TypeError, ValueError):
+                    pass
+            for key, child in value.items():
+                normalized = re.sub(r"[^a-z0-9]+", "_", str(key).lower())
+                child_context = kv_context or ("kv" in normalized and "cache" in normalized)
+                if child_context and isinstance(child, str) and any(
+                    marker in child.lower() for marker in ("fp8", "e4m3")
+                ):
+                    return True
+                if kv_metadata_is_fp8(child, child_context):
+                    return True
+        elif isinstance(value, list):
+            return any(kv_metadata_is_fp8(child, kv_context) for child in value)
+        return False
+
+    metadata = [load_json(path / "config.json")]
+    for name in ("hf_quant_config.json", "quantization_config.json", "quant_cfg.json"):
+        candidate = path / name
+        if candidate.is_file():
+            metadata.append(load_json(candidate))
+    return any(kv_metadata_is_fp8(item) for item in metadata)
+
+
+def inspect_model(path: Path, extra_external: list[str]) -> ModelInfo:
+    config_path = path / "config.json"
+    if not config_path.is_file():
+        raise SystemExit(f"Checkpoint has no config.json: {path}")
+    config = load_json(config_path)
+    model_type = str(config.get("model_type", ""))
+    text_config = config.get("text_config") if isinstance(config.get("text_config"), dict) else {}
+    thinker = config.get("thinker_config") if isinstance(config.get("thinker_config"), dict) else {}
+
+    metadata: list[Any] = [config]
+    quant_sidecars: dict[str, dict[str, Any]] = {}
+    for name in ("hf_quant_config.json", "quantization_config.json", "quant_cfg.json"):
+        candidate = path / name
+        if candidate.is_file():
+            quant_sidecars[name] = load_json(candidate)
+            metadata.append(quant_sidecars[name])
+
+    embedded_quant = config.get("quantization_config")
+    if not isinstance(embedded_quant, dict):
+        embedded_quant = {}
+    hf_quant = quant_sidecars.get("hf_quant_config.json", {}).get("quantization", {})
+    if not isinstance(hf_quant, dict):
+        hf_quant = {}
+    quant_declared = bool(embedded_quant or quant_sidecars)
+    quant_algo = hf_quant.get("quant_algo") or embedded_quant.get("quant_algo")
+    quant_method = str(embedded_quant.get("quant_method", "")).lower()
+    normalized_algo = str(quant_algo or "").upper()
+    modelopt_algo = normalized_algo == "MIXED_PRECISION" or any(
+        marker in normalized_algo
+        for marker in ("FP8", "MXFP8", "FP4", "NVFP4", "AWQ", "INT4_AWQ", "W8A8", "INT8")
+    )
+    if quant_declared and not (modelopt_algo or quant_method in {"awq", "gptq"}):
+        description = (
+            normalized_algo
+            or quant_method
+            or str(embedded_quant.get("format", "unknown"))
+        )
+        raise SystemExit(
+            f"Checkpoint quantization {description!r} is not supported by TensorRT "
+            f"Edge-LLM {EXPECTED_VERSION}; use a ModelOpt quant_algo, AWQ, or GPTQ checkpoint."
+        )
+    words = set()
+    for item in metadata:
+        words.update(walk_values(item))
+    flattened = " ".join(sorted(words))
+
+    is_nvfp4 = "nvfp4" in flattened or "nv_fp4" in flattened
+    is_int4 = not is_nvfp4 and any(token in flattened for token in ("int4", "w4a16", "gptq", "awq"))
+    is_moe = "moe" in model_type.lower() or has_moe_experts(config)
+
+    external = set(extra_external)
+    if is_int4:
+        external.add("int4_ffn")
+        if is_moe:
+            external.add("int4_moe")
+    if is_nvfp4 and is_moe:
+        external.add("nvfp4_moe")
+
+    has_visual = model_type == "alpamayo_r1" or (
+        model_type in VLM_MODEL_TYPES
+        and bool(config.get("vision_config") or thinker.get("vision_config") or config.get("vision_model_config"))
+    )
+    has_audio = model_type in AUDIO_MODEL_TYPES and bool(config.get("audio_config") or thinker.get("audio_config") or config.get("sound_config"))
+    is_tts = model_type == "qwen3_tts"
+    tts_mode = str(config.get("tts_model_type", "")).lower() if is_tts else ""
+    is_omni = model_type in OMNI_MODEL_TYPES
+    is_diffusion = model_type in {"diffusion_gemma", "diffusion_gemma_text"}
+    is_cosmos3_policy = model_type in {"cosmos3_omni", "cosmos3"}
+    is_cosmos3 = model_type == "cosmos3_edge" or is_cosmos3_policy
+    is_nemotron_asr = model_type == "nemotron3_5_asr"
+    has_visual = has_visual or (
+        (is_diffusion or model_type == "cosmos3_edge")
+        and isinstance(config.get("vision_config"), dict)
+    )
+    has_talker = is_tts or is_omni
+    has_cp = is_tts or is_omni
+
+    return ModelInfo(
+        path=path,
+        model_type=model_type,
+        has_llm=not (is_tts or is_cosmos3_policy or is_nemotron_asr),
+        has_visual=has_visual,
+        has_audio=has_audio or is_nemotron_asr,
+        has_talker=has_talker,
+        has_code_predictor=has_cp,
+        has_code2wav=is_tts or is_omni,
+        has_action=model_type == "alpamayo_r1",
+        is_tts=is_tts,
+        tts_mode=tts_mode,
+        is_omni=is_omni,
+        is_moe=is_moe,
+        is_diffusion=is_diffusion,
+        is_cosmos3=is_cosmos3,
+        is_cosmos3_policy=is_cosmos3_policy,
+        is_nemotron_asr=is_nemotron_asr,
+        external_weights=tuple(sorted(external)),
+    )
+
+
+def short_hash(value: Any, length: int = 10) -> str:
+    encoded = json.dumps(value, sort_keys=True, default=str, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()[:length]
+
+
+def safe_name(value: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", value.rstrip("/").split("/")[-1]).strip("-.")
+    return (name or "model")[:64]
+
+
+def shell_join(command: list[str]) -> str:
+    return shlex.join(str(item) for item in command)
+
+
+def update_symlink(link: Path, target: Path) -> None:
+    if link.is_symlink() or link.is_file():
+        link.unlink()
+    elif link.exists():
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+class CommandRunner:
+    def __init__(self, command_file: Path, log_file: Path, dry_run: bool):
+        self.command_file = command_file
+        self.log_file = log_file
+        self.dry_run = dry_run
+        command_file.parent.mkdir(parents=True, exist_ok=True)
+        command_file.write_text("#!/usr/bin/env bash\nset -euo pipefail\n\n", encoding="utf-8")
+
+    def run(
+        self,
+        command: list[str],
+        cwd: Path | None = None,
+        capture_file: Path | None = None,
+    ) -> None:
+        rendered = shell_join(command)
+        if cwd:
+            recorded = f"(cd {shlex.quote(str(cwd))} && {rendered})"
+        else:
+            recorded = rendered
+        with self.command_file.open("a", encoding="utf-8") as stream:
+            stream.write(recorded + "\n")
+        print(f"\n+ {recorded}", flush=True)
+        if self.dry_run:
+            return
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        if capture_file:
+            capture_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_file.open("a", encoding="utf-8") as log:
+            log.write(f"\n+ {recorded}\n")
+            process = subprocess.Popen(
+                command,
+                cwd=str(cwd) if cwd else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                errors="replace",
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            with (
+                capture_file.open("w", encoding="utf-8")
+                if capture_file
+                else open(os.devnull, "w", encoding="utf-8")
+            ) as capture:
+                for line in process.stdout:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+                    log.write(line)
+                    log.flush()
+                    if capture_file:
+                        capture.write(line)
+                        capture.flush()
+            returncode = process.wait()
+        if returncode:
+            raise SystemExit(f"Command failed with exit code {returncode}: {rendered}")
+
+
+def summarize_benchmarks(
+    bench_root: Path,
+    run_root: Path,
+    profile_json: Path | None,
+    batch_size: int,
+    include_runtime_summary: bool = False,
+) -> Path:
+    runtime_profile = None
+    if profile_json and profile_json.is_file():
+        runtime_profile = load_json(profile_json)
+
+    rows: list[dict[str, Any]] = []
+    for result in sorted(bench_root.rglob("e2e_*.csv")):
+        with result.open(newline="", encoding="utf-8") as stream:
+            for row in csv.DictReader(stream):
+                row["result_file"] = str(result.relative_to(run_root))
+                rows.append(row)
+
+    if include_runtime_summary:
+        if not runtime_profile:
+            raise SystemExit("The model runtime produced no profile for end-to-end benchmarking")
+        prefill = runtime_profile.get("prefill", {})
+        generation_key = "generation"
+        generation = runtime_profile.get(generation_key, {})
+        if not generation:
+            for candidate in ("mtp_generation", "eagle_generation"):
+                if runtime_profile.get(candidate):
+                    generation_key = candidate
+                    generation = runtime_profile[candidate]
+                    break
+        if generation_key == "generation":
+            generated_tokens = generation.get("generated_tokens")
+            generation_rate = generation.get("tokens_per_second")
+            generation_per_token_ms = generation.get("average_time_per_token_ms")
+        else:
+            generated_tokens = generation.get("total_generated_tokens")
+            generation_rate = generation.get("overall_tokens_per_second_excluding_base_prefill")
+            generation_per_token_ms = (
+                1000.0 / generation_rate
+                if isinstance(generation_rate, (int, float)) and generation_rate > 0
+                else None
+            )
+        required = (
+            (
+                "prefill.average_time_per_run_ms",
+                prefill.get("average_time_per_run_ms"),
+            ),
+            (
+                "prefill.average_tokens_per_run",
+                prefill.get("average_tokens_per_run"),
+            ),
+            ("prefill.tokens_per_second", prefill.get("tokens_per_second")),
+            (
+                f"{generation_key}.average_time_per_token_ms",
+                generation_per_token_ms,
+            ),
+            (f"{generation_key}.generated_tokens", generated_tokens),
+            (f"{generation_key}.tokens_per_second", generation_rate),
+        )
+        invalid = [
+            name
+            for name, value in required
+            if not isinstance(value, (int, float)) or value <= 0
+        ]
+        if invalid:
+            raise SystemExit(f"The model runtime profile is missing benchmark values: {', '.join(invalid)}")
+
+        assert profile_json is not None
+        try:
+            profile_result_file = str(profile_json.relative_to(run_root))
+        except ValueError:
+            profile_result_file = str(profile_json)
+        prefill_tokens = float(prefill["average_tokens_per_run"])
+        generated_tokens = int(generated_tokens)
+        generation_ms = float(generation_per_token_ms) * generated_tokens
+        runtime_rows = [
+            {
+                "mode": "prefill",
+                "batch_size": str(batch_size),
+                "osl": "1",
+                "e2e_time_ms": f"{float(prefill['average_time_per_run_ms']):.4f}",
+                "per_token_ms": f"{float(prefill.get('average_time_per_token_ms', 1000.0 / float(prefill['tokens_per_second']))):.4f}",
+                "throughput_tps": f"{float(prefill['tokens_per_second']):.4f}",
+                "input_len": str(int(prefill_tokens)),
+                "result_file": profile_result_file,
+                "source": "model_runtime_profile",
+            },
+            {
+                "mode": "decode",
+                "batch_size": str(batch_size),
+                "osl": str(generated_tokens),
+                "e2e_time_ms": f"{generation_ms:.4f}",
+                "per_token_ms": f"{float(generation_per_token_ms):.4f}",
+                "throughput_tps": f"{float(generation_rate):.4f}",
+                "past_kv_len": str(int(prefill_tokens)),
+                "result_file": profile_result_file,
+                "source": "model_runtime_profile",
+                "profile_section": generation_key,
+            },
+        ]
+        rows = [*runtime_rows, *rows]
+    elif not rows:
+        raise SystemExit(f"llm_bench produced no E2E timing CSV under {bench_root}")
+
+    summary = run_root / "benchmark_summary.json"
+    summary.write_text(json.dumps({
+        "llm_bench": rows,
+        "inference_profile": runtime_profile,
+    }, indent=2) + "\n", encoding="utf-8")
+
+    print("\nPerformance summary", flush=True)
+    for row in rows:
+        mode = row.get("mode", "unknown")
+        batch = row.get("batch_size", "?")
+        e2e_ms = row.get("e2e_time_ms", "?")
+        rate = row.get("throughput_tps") or row.get("trees_per_second") or "?"
+        unit = "trees/s" if row.get("trees_per_second") else "tokens/s"
+        shape = []
+        for key in (
+            "input_len", "past_kv_len", "osl", "image_height", "image_width",
+            "verify_tree_size", "draft_tree_size",
+        ):
+            value = row.get(key)
+            if value not in (None, ""):
+                shape.append(f"{key}={value}")
+        dimensions = " ".join(shape)
+        print(
+            f"  {mode:<24} BS={batch:<3} {dimensions:<48} "
+            f"{e2e_ms:>12} ms  {rate:>12} {unit}",
+            flush=True,
+        )
+    if runtime_profile:
+        for stage in runtime_profile.get("stages", []):
+            stage_id = stage.get("stage_id", "")
+            if stage_id not in {
+                "vision_encoder",
+                "audio_encoder",
+                "multimodal_processing",
+                "action_model",
+            }:
+                continue
+            average_ms = stage.get("average_time_per_run_ms")
+            if not isinstance(average_ms, (int, float)) or average_ms <= 0:
+                continue
+            print(
+                f"  {stage_id:<24} BS={batch_size:<3} "
+                f"{'runtime input':<48} {average_ms:>12.4f} ms  "
+                f"{1000.0 / average_ms:>12.2f} runs/s",
+                flush=True,
+            )
+    print(f"  summary                  {summary}", flush=True)
+    return summary
+
+
+def normalize_runtime_profile(path: Path, input_path: Path, info: ModelInfo) -> None:
+    """Map legacy stage names to their model-specific contract."""
+    if info.model_type != "gemma4" or not info.has_audio or not path.is_file():
+        return
+
+    requests = load_json(input_path).get("requests", [])
+    has_audio_input = any(
+        isinstance(content, dict) and content.get("type") == "audio"
+        for request in requests
+        if isinstance(request, dict)
+        for message in request.get("messages", [])
+        if isinstance(message, dict)
+        for content in (message.get("content") if isinstance(message.get("content"), list) else [])
+    )
+    if not has_audio_input:
+        return
+
+    profile = load_json(path)
+    stages = profile.get("stages", [])
+    if not isinstance(stages, list) or any(
+        isinstance(stage, dict) and stage.get("stage_id") == "audio_encoder"
+        for stage in stages
+    ):
+        return
+
+    legacy = next(
+        (
+            stage
+            for stage in stages
+            if isinstance(stage, dict) and stage.get("stage_id") == "multimodal_processing"
+        ),
+        None,
+    )
+    if legacy is None:
+        raise SystemExit("Gemma4 audio inference produced no runtime timing stage")
+
+    legacy["source_stage_id"] = legacy["stage_id"]
+    legacy["stage_id"] = "audio_encoder"
+    path.write_text(json.dumps(profile, indent=2) + "\n", encoding="utf-8")
+    print(
+        "Normalized the Gemma4 legacy multimodal_processing timing "
+        "to audio_encoder.",
+        flush=True,
+    )
+
+
+def export_tool(
+    home: Path, model_root: Path, compatibility: tuple[str, ...]
+) -> list[str]:
+    installed = shutil.which("tensorrt-edgellm-export")
+    if installed:
+        return [installed]
+    return [sys.executable, "-m", "tensorrt_edgellm.scripts.export"]
+
+
+def add_external_args(command: list[str], info: ModelInfo) -> None:
+    if info.external_weights:
+        command.extend(("--externalize-weights", *info.external_weights))
+
+
+def component_paths(info: ModelInfo, root: Path) -> dict[str, Path]:
+    if info.is_diffusion:
+        return {
+            "llm": root / "dllm",
+            "talker": root / "talker",
+            "code_predictor": root / "code_predictor",
+            "visual": root / "visual",
+            "audio": root / "audio",
+            "code2wav": root / "code2wav",
+            "action": root / "action",
+            "rnnt_decoder": root / "rnnt_decoder",
+            "mtp_draft": root / "mtp_draft",
+        }
+    if info.is_omni:
+        return {
+            "llm": root / "llm/thinker",
+            "talker": root / "llm/talker",
+            "code_predictor": root / "llm/code_predictor",
+            "visual": root / "vision",
+            "audio": root / "audio/audio_encoder",
+            "code2wav": root / "audio/code2wav",
+            "action": root / "action",
+            "rnnt_decoder": root / "rnnt_decoder",
+            "mtp_draft": root / "mtp_draft",
+        }
+    return {
+        "llm": root / "llm",
+        "talker": root / ("llm" if info.is_tts else "talker"),
+        "code_predictor": root / "code_predictor",
+        "visual": root / "visual",
+        "audio": root / "audio",
+        "code2wav": root / "code2wav",
+        "action": root / "action",
+        "rnnt_decoder": root / "rnnt_decoder",
+        "mtp_draft": root / "mtp_draft",
+    }
+
+
+def write_default_input(
+    path: Path,
+    args: argparse.Namespace,
+    info: ModelInfo,
+    home: Path,
+) -> None:
+    gemma_audio_prompt = (
+        "Transcribe the following speech segment in its original language. "
+        "Follow these specific instructions for formatting the answer:\n"
+        "* Only output the transcription, with no newlines.\n"
+        "* When transcribing numbers, write the digits, i.e. write 1.7 and not "
+        "one point seven, and write 3 instead of three."
+    )
+    prompts = list(args.prompt)
+    images = [item.expanduser().resolve() for item in args.image]
+    audios = [item.expanduser().resolve() for item in args.audio]
+    frames = [item.expanduser().resolve() for item in args.video_frame]
+    trajectory = args.trajectory
+    user_supplied = bool(prompts or images or audios or frames or trajectory or args.system_prompt)
+    split_modality_smoke = False
+
+    sample_image = home / "examples/multimodal/pics/woman_and_dog.jpeg"
+    sample_audio = home / "examples/multimodal/audio/6930-75918-0000.flac"
+    if not user_supplied and not args.text_only:
+        if info.has_action:
+            images = [sample_image] * 16
+            trajectory = json.dumps([[0.0, 0.0, 0.0]] * 16)
+        elif info.has_visual:
+            images = [sample_image]
+        if info.has_audio:
+            audios = [sample_audio]
+        split_modality_smoke = info.has_visual and info.has_audio
+
+    for media in (*images, *audios, *frames):
+        if not media.is_file():
+            raise SystemExit(f"Input media does not exist: {media}")
+
+    if not prompts and not split_modality_smoke:
+        if info.is_tts:
+            prompts = ["Hello, this is TensorRT Edge-LLM running on NVIDIA Jetson."]
+        elif info.has_action:
+            prompts = ["Explain the driving scene, then predict the future trajectory."]
+        elif images:
+            prompts = ["Describe this image in detail."]
+        elif audios:
+            prompts = [
+                gemma_audio_prompt
+                if info.model_type in PLE_MODEL_TYPES
+                else "Transcribe this audio."
+            ]
+        else:
+            prompts = ["What is the capital of the United States?"]
+    trajectory_data = None
+    if trajectory:
+        raw = trajectory
+        if not trajectory.lstrip().startswith("["):
+            trajectory_path = Path(trajectory).expanduser()
+            if trajectory_path.is_file():
+                raw = trajectory_path.read_text(encoding="utf-8")
+        try:
+            trajectory_data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Invalid --trajectory JSON: {exc}") from exc
+        if not isinstance(trajectory_data, list):
+            raise SystemExit("--trajectory must contain a JSON array")
+
+    if split_modality_smoke:
+        request_specs = [
+            ("Describe this image in detail.", images, [], [], None)
+            for _ in range(args.batch_size)
+        ]
+        request_specs.extend(
+            (
+                gemma_audio_prompt
+                if info.model_type in PLE_MODEL_TYPES
+                else "Transcribe this audio.",
+                [],
+                audios,
+                [],
+                None,
+            )
+            for _ in range(args.batch_size)
+        )
+    else:
+        if len(prompts) == 1 and args.batch_size > 1:
+            prompts *= args.batch_size
+        request_specs = [
+            (prompt, images, audios, frames, trajectory_data)
+            for prompt in prompts
+        ]
+
+    requests = []
+    for prompt, request_images, request_audios, request_frames, request_trajectory in request_specs:
+        if info.is_tts:
+            messages = [{"role": "assistant", "content": prompt}]
+        else:
+            messages = []
+            if args.system_prompt:
+                messages.append({"role": "system", "content": args.system_prompt})
+            content: list[dict[str, Any]] = []
+            content.extend({"type": "image", "image": str(item)} for item in request_images)
+            if request_frames:
+                content.append({
+                    "type": "video",
+                    "frames": [str(item) for item in request_frames],
+                    "fps": args.video_fps,
+                })
+            gemma_audio = info.model_type in PLE_MODEL_TYPES and bool(request_audios)
+            if gemma_audio and prompt:
+                content.append({"type": "text", "text": prompt})
+            content.extend(
+                {"type": "audio", "audio": str(item)} for item in request_audios
+            )
+            if request_trajectory is not None:
+                content.append({"type": "trajectory", "trajectory": request_trajectory})
+            if prompt and not gemma_audio:
+                content.append({"type": "text", "text": prompt})
+            messages.append({"role": "user", "content": content if len(content) != 1 or content[0]["type"] != "text" else prompt})
+        request: dict[str, Any] = {"messages": messages}
+        if info.is_tts:
+            request["speaker"] = args.speaker
+            request["language"] = args.language
+            if args.tts_instruct:
+                request["instruct"] = args.tts_instruct
+            elif info.tts_mode == "voice_design":
+                request["instruct"] = "Speak clearly in a warm, natural voice."
+            if info.tts_mode == "base":
+                reference = (
+                    args.ref_audio.expanduser().resolve()
+                    if args.ref_audio
+                    else sample_audio
+                )
+                if not reference.is_file():
+                    raise SystemExit(f"Reference audio does not exist: {reference}")
+                request["ref_audio"] = str(reference)
+                if args.ref_text:
+                    request["ref_text"] = args.ref_text
+        requests.append(request)
+
+    payload: dict[str, Any] = {
+        "batch_size": args.batch_size,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "top_k": args.top_k,
+        "max_generate_length": args.max_generate_length,
+        "enable_thinking": bool(args.enable_thinking),
+        "requests": requests,
+    }
+    if info.is_tts:
+        payload.update({
+            "talker_temperature": args.temperature,
+            "talker_top_k": args.top_k,
+            "talker_top_p": args.top_p,
+            "repetition_penalty": 1.05,
+            "max_audio_length": 4096,
+            "speaker": args.speaker,
+            "language": args.language,
+        })
+    if info.is_diffusion:
+        payload["diffusion_config"] = {
+            "max_denoising_steps": args.diffusion_steps,
+        }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def cosmos_policy_request(
+    args: argparse.Namespace, home: Path
+) -> tuple[str, str, list[str], dict[str, Any]]:
+    if args.input_json or args.audio or args.trajectory or args.system_prompt:
+        raise SystemExit(
+            "Cosmos3 policy accepts --image or --video-frame plus --prompt; "
+            "it does not use the LLM request JSON contract"
+        )
+    images = [item.expanduser().resolve() for item in args.image]
+    frames = [item.expanduser().resolve() for item in args.video_frame]
+    if images and frames:
+        raise SystemExit("Cosmos3 policy accepts either --image or --video-frame, not both")
+    if len(images) > 1:
+        raise SystemExit("Cosmos3 policy accepts one conditioning image")
+    if not images and not frames:
+        images = [home / "examples/multimodal/pics/woman_and_dog.jpeg"]
+    media = images or frames
+    for path in media:
+        if not path.is_file():
+            raise SystemExit(f"Input media does not exist: {path}")
+
+    prompts = list(args.prompt) or ["Move toward the requested object and grasp it safely."]
+    if len(prompts) == 1 and args.batch_size > 1:
+        prompts *= args.batch_size
+    if len(prompts) != args.batch_size:
+        raise SystemExit(
+            "Cosmos3 policy requires one --prompt per batch item, or one prompt "
+            "that can be repeated across --batch-size"
+        )
+    if frames:
+        source_option = "--video"
+        source_value = ",".join(str(path) for path in frames)
+    else:
+        source_option = "--image"
+        source_value = str(images[0])
+    payload = {
+        "contract": "cosmos3_policy",
+        "source": {"type": source_option.removeprefix("--"), "value": source_value},
+        "prompts": prompts,
+        "domain": args.policy_domain,
+        "viewpoint": args.policy_viewpoint,
+        "steps": args.policy_steps,
+        "seed": args.policy_seed,
+        "guidance": args.policy_guidance,
+        "video_subsample_factor": args.policy_video_subsample_factor,
+        "action_chunk_size": args.policy_action_chunk_size,
+    }
+    return source_option, source_value, prompts, payload
+
+
+def nemotron_asr_request(args: argparse.Namespace, home: Path) -> tuple[Path, dict[str, Any]]:
+    if args.input_json or args.image or args.video_frame or args.trajectory or args.prompt or args.system_prompt:
+        raise SystemExit(
+            "Nemotron-3.5-ASR accepts one --audio file and optional --asr-prompt-id; "
+            "it does not use the LLM request JSON contract"
+        )
+    audios = [item.expanduser().resolve() for item in args.audio]
+    if len(audios) > 1:
+        raise SystemExit("Nemotron-3.5-ASR accepts one audio file per invocation")
+    audio = audios[0] if audios else home / "examples/multimodal/audio/6930-75918-0000.flac"
+    if not audio.is_file():
+        raise SystemExit(f"Input audio does not exist: {audio}")
+    payload: dict[str, Any] = {
+        "contract": "nemotron3_5_asr",
+        "audio": str(audio),
+    }
+    if args.asr_prompt_id is not None:
+        payload["prompt_id"] = args.asr_prompt_id
+    return audio, payload
+
+
+def validate_input_json(path: Path, forbidden_content_types: tuple[str, ...] = ()) -> Path:
+    path = path.expanduser().resolve()
+    data = load_json(path)
+    if not isinstance(data.get("requests"), list) or not data["requests"]:
+        raise SystemExit(f"Edge-LLM input JSON must contain a non-empty requests array: {path}")
+    forbidden = set(forbidden_content_types)
+    for request in data["requests"]:
+        if not isinstance(request, dict):
+            continue
+        for message in request.get("messages", []):
+            if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+                continue
+            for item in message["content"]:
+                if isinstance(item, dict) and item.get("type") in forbidden:
+                    raise SystemExit(
+                        f"Content type {item['type']!r} is not supported for this model "
+                        f"by TensorRT Edge-LLM {EXPECTED_VERSION}"
+                    )
+    return path
+
+
+def ensure_software(
+    home: Path,
+    targets: dict[str, Path],
+    runner: CommandRunner,
+    skip: bool,
+) -> None:
+    missing = [name for name, path in targets.items() if not path.is_file()]
+    if not missing:
+        return
+    if skip:
+        details = ", ".join(f"{name} ({targets[name]})" for name in missing)
+        raise SystemExit(f"Required C++ executables are missing: {details}")
+    build_dir = home / "build"
+    if not build_dir.is_dir() and not runner.dry_run:
+        raise SystemExit(f"CMake build directory does not exist: {build_dir}")
+    experimental_targets = {
+        "cosmos3_policy_build",
+        "cosmos3_policy_inference",
+        "nemotron_asr_inference",
+    }
+    if experimental_targets.intersection(missing):
+        cache = build_dir / "CMakeCache.txt"
+        enabled = cache.is_file() and "BUILD_EXPERIMENTAL_MODELS:BOOL=ON" in cache.read_text(
+            encoding="utf-8", errors="replace"
+        )
+        if not enabled:
+            runner.run([
+                "cmake", "-S", str(home), "-B", str(build_dir),
+                "-DBUILD_EXPERIMENTAL_MODELS=ON",
+            ], home)
+    runner.run(["cmake", "--build", str(build_dir), "--target", *missing, "--parallel", str(os.cpu_count() or 1)], home)
+
+
+def main() -> None:
+    args = parser().parse_args()
+    if args.builder == "direct":
+        print("--builder direct is an alias for --builder weightless", flush=True)
+        args.builder = "weightless"
+    validate_args(args)
+    home = find_edgellm_home(args.edgellm_home)
+
+    version_file = home / "tensorrt_edgellm/_version.py"
+    if version_file.is_file():
+        match = re.search(r'__version__\s*=\s*["\']([^"\']+)', version_file.read_text(encoding="utf-8"))
+        if match and match.group(1) != EXPECTED_VERSION:
+            raise SystemExit(f"This workflow targets Edge-LLM {EXPECTED_VERSION}, but {home} contains {match.group(1)}")
+
+    metadata_only = args.dry_run or (
+        args.builder == "onnx" and args.stage in {"build", "infer", "bench"}
+    )
+    materialize_root = (
+        args.workspace.expanduser().resolve() / "checkpoints"
+        if args.builder == "onnx"
+        else None
+    )
+    materialize = (
+        args.builder == "onnx"
+        and args.stage in {"all", "export", "serve"}
+        and not args.dry_run
+    )
+    checkpoint_args = {
+        "metadata_only": metadata_only,
+        "materialize_root": materialize_root,
+        "materialize": materialize,
+    }
+    base_path = resolve_checkpoint(
+        args.model, args.revision, args.local_files_only, **checkpoint_args
+    )
+    info = inspect_model(base_path, args.externalize_weight)
+    if not info.is_tts and any((
+        args.tts_instruct, args.ref_audio, args.ref_text,
+        args.language != "auto",
+    )):
+        raise SystemExit(
+            "--language, --tts-instruct, --ref-audio, and --ref-text require "
+            "a Qwen3-TTS checkpoint"
+        )
+    if args.builder == "weightless" and info.is_nemotron_asr:
+        raise SystemExit(
+            "Nemotron-3.5-ASR requires --builder onnx because Edge-LLM 0.10.0 "
+            "builds its FastConformer and RNN-T step with audio_build"
+        )
+    draft_info = None
+    if args.draft_model:
+        draft_path = resolve_checkpoint(
+            args.draft_model, args.revision, args.local_files_only, **checkpoint_args
+        )
+        draft_info = inspect_model(draft_path, args.externalize_weight)
+    else:
+        draft_path = None
+
+    omni_root_info = talker_info = None
+    if args.omni_root_model:
+        omni_root_path = resolve_checkpoint(
+            args.omni_root_model, args.revision, args.local_files_only, **checkpoint_args
+        )
+        talker_path = resolve_checkpoint(
+            args.talker_model, args.revision, args.local_files_only, **checkpoint_args
+        )
+        omni_root_info = inspect_model(omni_root_path, args.externalize_weight)
+        talker_info = inspect_model(talker_path, args.externalize_weight)
+        if not omni_root_info.is_omni:
+            raise SystemExit("--omni-root-model must be a Qwen3-Omni full checkpoint")
+        info = ModelInfo(
+            path=info.path,
+            model_type=omni_root_info.model_type,
+            has_llm=True,
+            has_visual=omni_root_info.has_visual,
+            has_audio=omni_root_info.has_audio,
+            has_talker=True,
+            has_code_predictor=True,
+            has_code2wav=True,
+            has_action=False,
+            is_tts=False,
+            tts_mode="",
+            is_omni=True,
+            is_moe=True,
+            is_diffusion=False,
+            is_cosmos3=False,
+            is_cosmos3_policy=False,
+            is_nemotron_asr=False,
+            external_weights=info.external_weights,
+        )
+
+    if args.spec_mode == "eagle3" and draft_info is None:
+        raise SystemExit("--eagle3 requires a draft checkpoint")
+    if args.spec_mode in {"dflash", "dspark"} and draft_info is None:
+        raise SystemExit(f"--{args.spec_mode} requires a draft checkpoint")
+    if args.spec_mode == "mtp" and info.model_type in PLE_MODEL_TYPES and draft_info is None:
+        raise SystemExit("Gemma4 --mtp requires --mtp-draft with the matched assistant checkpoint")
+    if args.spec_mode != "none" and (info.is_tts or info.has_action or info.is_omni):
+        raise SystemExit(f"{args.spec_mode} is not supported by this release workflow for model_type={info.model_type}")
+    if args.builder == "weightless" and omni_root_info:
+        raise SystemExit("The weightless builder accepts one complete Qwen3-Omni checkpoint; remove the split-checkpoint options")
+    if args.stage == "serve":
+        if info.model_type in PLE_MODEL_TYPES and checkpoint_uses_fp8_kv_cache(info.path):
+            raise SystemExit(
+                "TensorRT Edge-LLM 0.10.0 cannot serve Gemma4 shared-KV "
+                "attention with an FP8 KV cache; select a Gemma4 checkpoint "
+                "with an FP16 KV cache"
+            )
+        if info.is_tts and info.tts_mode != "custom_voice":
+            raise SystemExit(
+                "The 0.10.0 HTTP speech endpoint supports Qwen3-TTS "
+                "CustomVoice checkpoints. Base voice cloning and VoiceDesign "
+                "keep their model-specific offline input contracts."
+            )
+        if info.is_diffusion:
+            raise SystemExit(
+                "DiffusionGemma uses the block-diffusion C++ runtime and is not "
+                "loadable by the 0.10.0 generic HTTP server"
+            )
+        if info.has_action or info.is_cosmos3_policy or info.is_nemotron_asr:
+            raise SystemExit(
+                "This helper's server stage supports LLM, VLM, LLM-backed ASR, "
+                "and Qwen3-TTS CustomVoice engines; use offline inference for "
+                "Cosmos3 policy, Alpamayo action, or RNN-T ASR contracts"
+            )
+
+    low_memory_orin = 0 < system_memory_gib() < 10
+    defaults = {
+        "batch": 1 if info.is_cosmos3_policy or info.is_nemotron_asr else (6 if info.has_action else 1),
+        "input": 3424 if info.has_action else (
+            4096 if info.is_tts else (
+                2304 if info.has_visual and info.has_audio else (
+                    1024 if info.is_omni else (1152 if low_memory_orin else 2048)
+                )
+            )
+        ),
+        "kv": 4096 if info.has_action or info.is_tts else (
+            2500 if info.has_visual and info.has_audio else (
+                2048 if info.is_omni else (1280 if low_memory_orin else 2200)
+            )
+        ),
+    }
+    max_batch = args.max_batch_size or defaults["batch"]
+    max_input = args.max_input_len or defaults["input"]
+    max_kv = args.max_kv_cache_capacity or defaults["kv"]
+    if args.batch_size > max_batch:
+        raise SystemExit(f"--batch-size {args.batch_size} exceeds engine --max-batch-size {max_batch}")
+
+    if info.has_action:
+        min_image = args.min_image_tokens or 160
+        max_image = args.max_image_tokens or 18432
+        max_per_image = args.max_image_tokens_per_image or 192
+    else:
+        min_image = args.min_image_tokens or 8
+        max_image = args.max_image_tokens or (2048 if low_memory_orin else 16384)
+        max_per_image = args.max_image_tokens_per_image or (1024 if low_memory_orin else 2048)
+    if not (min_image <= max_per_image <= max_image):
+        raise SystemExit("Image token profiles require min <= max-per-image <= max")
+
+    spec_defaults = {
+        "none": (0, 0, 0),
+        "mtp": (1, 3, 4),
+        "eagle3": (10, 6, 60),
+        "dflash": (1, 1, 16),
+        "dspark": (1, 1, 8),
+    }
+    default_top_k, default_steps, default_verify = spec_defaults[args.spec_mode]
+    draft_top_k = args.draft_top_k or default_top_k
+    draft_steps = args.draft_steps or default_steps
+    verify_size = args.verify_size or default_verify
+    if args.spec_mode == "mtp" and (draft_top_k != 1 or verify_size != draft_steps + 1):
+        raise SystemExit("MTP requires --draft-top-k 1 and --verify-size == --draft-steps + 1")
+    if args.spec_mode in {"dflash", "dspark"} and draft_steps != 1:
+        raise SystemExit(f"{args.spec_mode} requires --draft-steps 1")
+    if args.spec_mode == "dflash" and args.enable_thinking is None:
+        args.enable_thinking = info.model_type in {"qwen3_5", "qwen3_5_text", "qwen3_5_moe"}
+    if args.enable_thinking is None:
+        args.enable_thinking = False
+
+    prefill_len = args.prefill_len or min(2048, max_input)
+    decode_reserve = max(args.bench_output_len, verify_size, args.dflash_block_size)
+    past_kv_len = args.past_kv_len or min(2048, max_kv - decode_reserve)
+    if prefill_len > max_input:
+        raise SystemExit(
+            f"--prefill-len {prefill_len} exceeds --max-input-len {max_input}; "
+            "increase the engine profile or lower the benchmark length"
+        )
+    if past_kv_len < 0 or past_kv_len + decode_reserve > max_kv:
+        raise SystemExit(
+            f"--past-kv-len {past_kv_len} plus the {decode_reserve}-token benchmark reserve "
+            f"exceeds --max-kv-cache-capacity {max_kv}"
+        )
+
+    model_identity = {
+        "model": args.model,
+        "resolved": str(base_path),
+        "revision": args.revision,
+    }
+    weightless_external_weights = (
+        tuple(args.externalize_weight)
+        if args.externalize_weight
+        else WEIGHTLESS_EXTERNAL_WEIGHT_KINDS
+    )
+    model_root = args.workspace.expanduser().resolve() / f"{safe_name(args.model)}-{short_hash(model_identity, 8)}"
+    model_root.mkdir(parents=True, exist_ok=True)
+    if args.builder == "onnx":
+        export_base_path, gemma4_compatibility = prepare_gemma4_checkpoint(
+            base_path, model_root, info.model_type
+        )
+    else:
+        export_base_path, gemma4_compatibility = base_path, ()
+
+    export_signature = {
+        **model_identity,
+        "spec": args.spec_mode,
+        "draft": str(draft_path or ""),
+        "omni_root": str(omni_root_info.path if omni_root_info else ""),
+        "talker": str(talker_info.path if talker_info else ""),
+        "external": info.external_weights,
+        "kv": max_kv,
+        "extra": args.export_arg,
+        "dflash_tree": args.spec_mode == "dflash" and draft_top_k > 1,
+        "gemma4_compatibility": gemma4_compatibility,
+        "builder": args.builder,
+    }
+    export_root = model_root / "onnx" / f"{args.spec_mode}-{short_hash(export_signature)}"
+    engine_signature = {
+        "export": export_signature,
+        "batch": max_batch,
+        "input": max_input,
+        "kv": max_kv,
+        "verify": verify_size,
+        "draft_top_k": draft_top_k,
+        "draft_steps": draft_steps,
+        "dflash_block": args.dflash_block_size,
+        "image": (min_image, max_image, max_per_image) if info.has_visual else None,
+        "audio": (args.min_audio_time_steps, args.max_audio_time_steps) if info.has_audio else None,
+        "code": args.max_code_length if info.has_code2wav else None,
+        "build_args": {
+            "llm": args.llm_build_arg if info.has_llm else (),
+            "talker": args.talker_build_arg if info.has_talker else (),
+            "cp": args.code_predictor_build_arg if info.has_code_predictor else (),
+            "visual": args.visual_build_arg if info.has_visual else (),
+            "audio": args.audio_build_arg if info.has_audio or info.has_code2wav else (),
+            "action": args.action_build_arg if info.has_action else (),
+            "weightless": args.weightless_build_arg if args.builder == "weightless" else (),
+            "weightless_external": (
+                weightless_external_weights
+                if args.builder == "weightless"
+                else ()
+            ),
+        },
+    }
+    engine_root = model_root / "engines" / f"b{max_batch}-i{max_input}-kv{max_kv}-{args.spec_mode}-{short_hash(engine_signature, 8)}"
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + f"-{os.getpid()}"
+    run_root = model_root / "runs" / run_id
+    run_root.mkdir(parents=True, exist_ok=True)
+    command_file = run_root / "commands.sh"
+    runner = CommandRunner(command_file, run_root / "pipeline.log", args.dry_run)
+
+    runtime_profile_benchmark = (
+        info.model_type in PLE_MODEL_TYPES
+        or info.is_diffusion
+        or info.is_cosmos3_policy
+        or info.is_nemotron_asr
+        or args.spec_mode != "none"
+    )
+    need_export = args.builder == "onnx" and args.stage in {"all", "export", "serve"}
+    need_build = args.stage in {"all", "build", "serve"}
+    need_bench = args.stage in {"all", "bench"} and not args.no_benchmark
+    need_infer = (
+        args.stage in {"all", "infer"} and not args.no_inference
+    ) or (need_bench and runtime_profile_benchmark)
+    need_server = args.stage == "serve"
+    if need_bench and runtime_profile_benchmark and args.no_inference:
+        raise SystemExit("This model's end-to-end benchmark requires its runtime; remove --no-inference")
+
+    if need_export and args.force_export and export_root.exists() and not args.dry_run:
+        shutil.rmtree(export_root)
+    if need_export:
+        marker = export_root / ".complete"
+        if marker.is_file() and not args.force_export and not args.dry_run:
+            print(f"Reusing ONNX export: {export_root}")
+        else:
+            export_root.mkdir(parents=True, exist_ok=True)
+            tool = export_tool(home, model_root, gemma4_compatibility)
+            if omni_root_info and talker_info:
+                commands = []
+                thinker_cmd = [*tool, str(export_base_path), str(export_root / "thinker")]
+                add_external_args(thinker_cmd, inspect_model(base_path, args.externalize_weight))
+                commands.append(thinker_cmd)
+                talker_cmd = [*tool, str(talker_info.path), str(export_root / "talker"), "--talker-sidecar-from", str(omni_root_info.path)]
+                add_external_args(talker_cmd, talker_info)
+                commands.append(talker_cmd)
+                root_cmd = [*tool, str(omni_root_info.path), str(export_root / "multimodal"), "--components", "visual,audio,code2wav,code_predictor"]
+                add_external_args(root_cmd, omni_root_info)
+                commands.append(root_cmd)
+            elif args.spec_mode == "eagle3":
+                base_cmd = [*tool, str(export_base_path), str(export_root / "base"), "--eagle-base", "--max-kv-cache-capacity", str(max_kv)]
+                add_external_args(base_cmd, info)
+                draft_cmd = [*tool, str(draft_path), str(export_root / "draft")]
+                add_external_args(draft_cmd, draft_info)
+                commands = [base_cmd, draft_cmd]
+            elif args.spec_mode == "dflash":
+                base_flag = "--dflash-tree-base" if draft_top_k > 1 else "--dflash-base"
+                base_cmd = [*tool, str(export_base_path), str(export_root / "base"), base_flag, "--dflash-draft-dir", str(draft_path), "--max-kv-cache-capacity", str(max_kv)]
+                add_external_args(base_cmd, info)
+                draft_cmd = [*tool, str(export_base_path), str(export_root / "draft"), "--dflash-draft", "--dflash-draft-dir", str(draft_path)]
+                commands = [base_cmd, draft_cmd]
+            elif args.spec_mode == "dspark":
+                base_cmd = [*tool, str(export_base_path), str(export_root / "base"), "--dspark-base", "--dspark-draft-dir", str(draft_path), "--max-kv-cache-capacity", str(max_kv)]
+                add_external_args(base_cmd, info)
+                draft_cmd = [*tool, str(export_base_path), str(export_root / "draft"), "--dspark-draft", "--dspark-draft-dir", str(draft_path)]
+                commands = [base_cmd, draft_cmd]
+            else:
+                command = [*tool, str(export_base_path), str(export_root), "--max-kv-cache-capacity", str(max_kv)]
+                if info.is_cosmos3_policy:
+                    command.extend(("--task", "policy"))
+                elif info.is_cosmos3:
+                    command.extend(("--task", "reasoning"))
+                if args.spec_mode == "mtp":
+                    command.append("--mtp")
+                    if draft_path:
+                        command.extend(("--mtp-draft-dir", str(draft_path)))
+                add_external_args(command, info)
+                commands = [command]
+            for command in commands:
+                command.extend(args.export_arg)
+                runner.run(command, home)
+            if not args.dry_run:
+                marker.write_text(json.dumps(export_signature, indent=2, default=str) + "\n", encoding="utf-8")
+
+    if export_root.is_dir() and not args.dry_run:
+        normalize_tokenizers(export_root)
+
+    if omni_root_info and talker_info:
+        paths = {
+            "llm": export_root / "thinker/llm",
+            "talker": export_root / "talker/llm",
+            "code_predictor": export_root / "multimodal/code_predictor",
+            "visual": export_root / "multimodal/visual",
+            "audio": export_root / "multimodal/audio",
+            "code2wav": export_root / "multimodal/code2wav",
+            "action": export_root / "multimodal/action",
+        }
+    elif args.spec_mode == "eagle3":
+        base_paths = component_paths(info, export_root / "base")
+        paths = dict(base_paths)
+        paths["spec_base"] = base_paths["llm"]
+        paths["spec_draft"] = export_root / "draft/llm"
+    elif args.spec_mode in {"dflash", "dspark"}:
+        base_paths = component_paths(info, export_root / "base")
+        paths = dict(base_paths)
+        paths["spec_base"] = base_paths["llm"]
+        draft_component = "dflash_draft" if args.spec_mode == "dflash" else "dspark_draft"
+        paths["spec_draft"] = export_root / "draft" / draft_component
+    else:
+        paths = component_paths(info, export_root)
+        if args.spec_mode == "mtp":
+            paths["spec_base"] = paths["llm"]
+            paths["spec_draft"] = paths["mtp_draft"]
+
+    binary = {
+        "llm_build": home / "build/examples/llm/llm_build",
+        "llm_inference": home / "build/examples/llm/llm_inference",
+        "llm_bench": home / "build/examples/llm/llm_bench",
+        "visual_build": home / "build/examples/multimodal/visual_build",
+        "audio_build": home / "build/examples/multimodal/audio_build",
+        "action_build": home / "build/examples/multimodal/action_build",
+        "action_inference": home / "build/examples/multimodal/action_inference",
+        "qwen3_tts_inference": home / "build/examples/omni/qwen3_tts_inference",
+        "cosmos3_policy_build": home / "build/experimental_models/cosmos3/examples/cosmos3_policy_build",
+        "cosmos3_policy_inference": home / "build/experimental_models/cosmos3/examples/cosmos3_policy_inference",
+        "nemotron_asr_inference": home / "build/experimental_models/nemotron3_5_asr/examples/nemotron_asr_inference",
+    }
+    required_targets: dict[str, Path] = {}
+    if need_build and args.builder == "onnx":
+        if info.is_cosmos3_policy:
+            required_targets["cosmos3_policy_build"] = binary["cosmos3_policy_build"]
+        else:
+            if info.has_llm or info.has_talker:
+                required_targets["llm_build"] = binary["llm_build"]
+            if info.has_visual:
+                required_targets["visual_build"] = binary["visual_build"]
+            if info.has_audio or info.has_code2wav:
+                required_targets["audio_build"] = binary["audio_build"]
+            if info.has_action:
+                required_targets["action_build"] = binary["action_build"]
+    if need_infer:
+        runtime_target = (
+            "cosmos3_policy_inference"
+            if info.is_cosmos3_policy
+            else (
+                "nemotron_asr_inference"
+                if info.is_nemotron_asr
+                else (
+                    "qwen3_tts_inference"
+                    if info.is_tts
+                    else ("action_inference" if info.has_action else "llm_inference")
+                )
+            )
+        )
+        required_targets[runtime_target] = binary[runtime_target]
+    benchmark_summary = None
+    if (
+        need_bench
+        and not (info.is_tts or info.is_cosmos3_policy or info.is_nemotron_asr)
+        and (args.spec_mode != "none" or not runtime_profile_benchmark)
+    ):
+        required_targets["llm_bench"] = binary["llm_bench"]
+    if required_targets:
+        ensure_software(home, required_targets, runner, args.skip_software_build)
+
+    if need_build and args.force_build and engine_root.exists() and not args.dry_run:
+        shutil.rmtree(engine_root)
+    if need_build:
+        engine_root.mkdir(parents=True, exist_ok=True)
+    engine_marker = engine_root / ".complete"
+    if args.builder == "weightless":
+        llm_engine = engine_root / "talker" if info.is_tts else engine_root
+        multimodal_engine = engine_root
+    else:
+        llm_engine = engine_root / ("talker" if info.is_tts else ("thinker" if info.is_omni else "llm"))
+        multimodal_engine = engine_root / "multimodal"
+
+    def invalidate_engine_bundle() -> None:
+        if not args.dry_run:
+            engine_marker.unlink(missing_ok=True)
+
+    def require_onnx(component: str) -> Path:
+        directory = paths[component]
+        if not args.dry_run and not (directory / "model.onnx").is_file():
+            raise SystemExit(f"Missing {component} ONNX artifact: {directory / 'model.onnx'}")
+        return directory
+
+    def link_external_weights(onnx_dir: Path, out: Path, role: str) -> None:
+        if args.dry_run:
+            return
+        config_path = onnx_dir / "config.json"
+        config = load_json(config_path)
+        entries = config.get("external_weight_files", [])
+        if not isinstance(entries, list):
+            raise SystemExit(f"external_weight_files must be an array in {config_path}")
+        out.mkdir(parents=True, exist_ok=True)
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("file"), str):
+                raise SystemExit(f"Malformed external weight entry in {config_path}: {entry!r}")
+            filename = entry["file"]
+            source = (onnx_dir / filename).resolve()
+            if onnx_dir.resolve() not in source.parents or not source.is_file():
+                raise SystemExit(f"Invalid external weight file in {config_path}: {filename}")
+            destination = out / (("draft_" if role == "draft" else "") + filename)
+            if destination.exists():
+                if source.samefile(destination):
+                    continue
+                if destination.is_file() and source.stat().st_size == destination.stat().st_size:
+                    print(f"Reusing copied external weight file: {destination}", flush=True)
+                    continue
+                destination.unlink()
+            temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+            temporary.unlink(missing_ok=True)
+            try:
+                os.link(source, temporary)
+                os.replace(temporary, destination)
+                print(f"Linked external weight file: {source} -> {destination}", flush=True)
+            except OSError:
+                temporary.unlink(missing_ok=True)
+                try:
+                    shutil.copy2(source, temporary)
+                    os.replace(temporary, destination)
+                    print(f"Copied external weight file: {source} -> {destination}", flush=True)
+                finally:
+                    temporary.unlink(missing_ok=True)
+
+    def build_llm(component: str, out: Path, role: str = "", component_args: list[str] | None = None, component_input: int | None = None, component_kv: int | None = None) -> None:
+        expected = out / (
+            "spec_base.engine" if role == "base" else (
+                "spec_draft.engine" if role == "draft" else (
+                    "dllm.engine" if info.is_diffusion else "llm.engine"
+                )
+            )
+        )
+        onnx_dir = require_onnx(component)
+        link_external_weights(onnx_dir, out, role)
+        if expected.is_file() and engine_marker.is_file() and not args.force_build and not args.dry_run:
+            print(f"Reusing engine: {expected}")
+            return
+        invalidate_engine_bundle()
+        command = [
+            str(binary["llm_build"]), "--onnxDir", str(onnx_dir), "--engineDir", str(out),
+            "--maxBatchSize", str(max_batch), "--maxInputLen", str(component_input or max_input),
+            "--maxKVCacheCapacity", str(component_kv or max_kv),
+        ]
+        if role == "base":
+            command.extend(("--specBase", "--maxVerifyTreeSize", str(verify_size)))
+        elif role == "draft":
+            draft_tree_size = (
+                7
+                if args.spec_mode == "dspark"
+                else max(verify_size, args.dflash_block_size)
+            )
+            command.extend(("--specDraft", "--maxDraftTreeSize", str(draft_tree_size)))
+        command.extend(args.llm_build_arg)
+        command.extend(component_args or [])
+        runner.run(command, home)
+
+    if need_build and args.builder == "weightless":
+        direct_builder = shutil.which("tensorrt-edgellm-build")
+        if not direct_builder:
+            raise SystemExit("tensorrt-edgellm-build is not installed in this container")
+        expected_engine = (
+            engine_root / "talker/llm.engine"
+            if info.is_tts
+            else (
+                engine_root / "gen/gen.engine"
+                if info.is_cosmos3_policy
+                else engine_root / (
+                    "spec_base.engine" if args.spec_mode != "none" else (
+                        "dllm.engine" if info.is_diffusion else "llm.engine"
+                    )
+                )
+            )
+        )
+        if expected_engine.is_file() and engine_marker.is_file() and not args.force_build and not args.dry_run:
+            print(f"Reusing weightless engine bundle: {engine_root}")
+        else:
+            command = [
+                direct_builder,
+                "--model-dir", str(base_path),
+                "--engine-dir", str(engine_root),
+                "--plugin-path", str(home / "build/libNvInfer_edgellm_plugin.so"),
+                "--max-batch-size", str(max_batch),
+                "--max-input-len", str(max_input),
+                "--max-kv-cache-capacity", str(max_kv),
+            ]
+            if info.is_cosmos3_policy:
+                command.extend(("--components", "und-prefill,gen,vae-encoder"))
+            elif info.is_cosmos3:
+                command.extend(("--components", "llm,visual"))
+            elif info.is_diffusion:
+                command.extend(("--components", "dllm,visual"))
+            if info.has_visual:
+                command.extend((
+                    "--min-image-tokens", str(min_image),
+                    "--max-image-tokens", str(max_image),
+                    "--max-image-tokens-per-image", str(max_per_image),
+                ))
+            if info.has_audio:
+                command.extend((
+                    "--min-time-steps", str(args.min_audio_time_steps),
+                    "--max-time-steps", str(args.max_audio_time_steps),
+                ))
+            if info.has_code2wav:
+                command.extend(("--max-code-len", str(args.max_code_length)))
+            if args.spec_mode != "none":
+                spec_type = (
+                    "gemma4_mtp"
+                    if args.spec_mode == "mtp" and info.model_type in PLE_MODEL_TYPES
+                    else args.spec_mode
+                )
+                command.extend(("--spec-type", spec_type))
+                if draft_path:
+                    command.extend(("--draft-model-dir", str(draft_path)))
+                direct_draft_size = 7 if args.spec_mode == "dspark" else max(
+                    verify_size, args.dflash_block_size
+                )
+                command.extend((
+                    "--max-verify-tree-size", str(verify_size),
+                    "--max-draft-tree-size", str(direct_draft_size),
+                ))
+                if args.spec_mode in {"dflash", "dspark"} and draft_top_k > 1:
+                    command.append("--tree-base")
+            for weight_kind in args.externalize_weight:
+                command.extend(("--externalize-weights", weight_kind))
+            command.extend(args.weightless_build_arg)
+            runner.run(command, home)
+            if not args.dry_run:
+                engine_marker.write_text(json.dumps(engine_signature, indent=2, default=str) + "\n", encoding="utf-8")
+        if info.is_cosmos3_policy and not args.dry_run:
+            ensure_processed_chat_template(
+                base_path / "text_tokenizer",
+                engine_root / "text_tokenizer",
+            )
+
+    if need_build and args.builder == "onnx":
+        if info.is_cosmos3_policy:
+            expected = engine_root / "gen/gen.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                runner.run([
+                    str(binary["cosmos3_policy_build"]),
+                    "--onnxDir", str(export_root),
+                    "--engineDir", str(engine_root),
+                    "--maxBatchSize", str(max_batch),
+                ], home)
+        elif info.is_nemotron_asr:
+            runtime_dir = engine_root / "runtime"
+            expected = runtime_dir / "rnnt_step.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                runner.run([
+                    str(binary["audio_build"]),
+                    "--onnxDir", str(require_onnx("audio")),
+                    "--engineDir", str(engine_root),
+                    "--maxTimeSteps", str(args.max_audio_time_steps),
+                    *args.audio_build_arg,
+                ], home)
+                runner.run([
+                    str(binary["audio_build"]),
+                    "--onnxDir", str(require_onnx("rnnt_decoder")),
+                    "--engineDir", str(engine_root),
+                    *args.audio_build_arg,
+                ], home)
+                runtime_files = [
+                    engine_root / "audio/audio_encoder.engine",
+                    engine_root / "rnnt_decoder/rnnt_step.engine",
+                    paths["audio"] / "config.json",
+                    paths["audio"] / "tokenizer.json",
+                    paths["audio"] / "tokenizer_config.json",
+                ]
+                runner.run(["cmake", "-E", "make_directory", str(runtime_dir)], home)
+                runner.run([
+                    "cmake", "-E", "copy_if_different",
+                    *(str(path) for path in runtime_files),
+                    str(runtime_dir),
+                ], home)
+        elif args.spec_mode != "none":
+            build_llm("spec_base", llm_engine, "base")
+            build_llm("spec_draft", llm_engine, "draft")
+        elif info.has_llm:
+            build_llm("llm", llm_engine)
+        if info.has_talker:
+            talker_engine = engine_root / "talker"
+            talker_input = 4096 if info.is_tts else max_input
+            talker_kv = 4096 if info.is_tts else max_kv
+            build_llm("talker", talker_engine, component_args=args.talker_build_arg, component_input=talker_input, component_kv=talker_kv)
+        else:
+            talker_engine = engine_root / "talker"
+        if info.has_code_predictor:
+            cp_input = 4096 if info.is_tts else 256
+            cp_kv = 4096 if info.is_tts else 256
+            build_llm("code_predictor", engine_root / "code_predictor", component_args=args.code_predictor_build_arg, component_input=cp_input, component_kv=cp_kv)
+        if info.has_visual:
+            expected = multimodal_engine / "visual/visual.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                command = [
+                    str(binary["visual_build"]), "--onnxDir", str(require_onnx("visual")), "--engineDir", str(multimodal_engine),
+                    "--minImageTokens", str(min_image), "--maxImageTokens", str(max_image),
+                    "--maxImageTokensPerImage", str(max_per_image), *args.visual_build_arg,
+                ]
+                runner.run(command, home)
+        if info.has_audio and not info.is_nemotron_asr:
+            expected = multimodal_engine / "audio/audio_encoder.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                command = [
+                    str(binary["audio_build"]), "--onnxDir", str(require_onnx("audio")), "--engineDir", str(multimodal_engine),
+                    "--minTimeSteps", str(args.min_audio_time_steps), "--maxTimeSteps", str(args.max_audio_time_steps),
+                    *args.audio_build_arg,
+                ]
+                runner.run(command, home)
+        if info.has_code2wav:
+            expected = engine_root / "code2wav/code2wav.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                command = [
+                    str(binary["audio_build"]), "--onnxDir", str(require_onnx("code2wav")), "--engineDir", str(engine_root),
+                    "--maxCodeLen", str(args.max_code_length), *args.audio_build_arg,
+                ]
+                runner.run(command, home)
+        if info.is_tts and info.tts_mode == "base":
+            clone_onnx = export_root / "clone_encoders"
+            clone_engine = engine_root / "clone_encoders"
+            speaker_onnx = clone_onnx / "speaker_encoder.onnx"
+            tokenizer_onnx = clone_onnx / "speech_tokenizer_encoder.onnx"
+            if not args.dry_run:
+                for required in (speaker_onnx, tokenizer_onnx):
+                    if not required.is_file():
+                        raise SystemExit(f"Missing Qwen3-TTS Base clone encoder: {required}")
+            trtexec = shutil.which("trtexec")
+            if not trtexec and not args.dry_run:
+                raise SystemExit("trtexec is required to build Qwen3-TTS Base clone encoders")
+            trtexec = trtexec or "trtexec"
+            runner.run(["cmake", "-E", "make_directory", str(clone_engine)], home)
+            speaker_engine = clone_engine / "speaker_encoder.engine"
+            if not speaker_engine.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                runner.run([
+                    trtexec,
+                    f"--onnx={speaker_onnx}",
+                    "--fp16",
+                    "--minShapes=wav:1x24000",
+                    "--optShapes=wav:1x240000",
+                    "--maxShapes=wav:1x960000",
+                    f"--saveEngine={speaker_engine}",
+                ], home)
+            tokenizer_engine = clone_engine / "speech_tokenizer_encoder.engine"
+            if not tokenizer_engine.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                runner.run([
+                    trtexec,
+                    f"--onnx={tokenizer_onnx}",
+                    "--fp16",
+                    f"--saveEngine={tokenizer_engine}",
+                ], home)
+        if info.has_action:
+            expected = multimodal_engine / "action/action.engine"
+            if not expected.is_file() or not engine_marker.is_file() or args.force_build or args.dry_run:
+                invalidate_engine_bundle()
+                command = [
+                    str(binary["action_build"]), "--onnxDir", str(require_onnx("action")), "--engineDir", str(multimodal_engine),
+                    "--maxBatchSize", str(max_batch), *args.action_build_arg,
+                ]
+                runner.run(command, home)
+        if not args.dry_run:
+            engine_marker.write_text(json.dumps(engine_signature, indent=2, default=str) + "\n", encoding="utf-8")
+
+    if engine_root.is_dir() and not args.dry_run:
+        normalize_tokenizers(engine_root)
+
+    if not args.dry_run:
+        if (export_root / ".complete").is_file():
+            update_symlink(model_root / "latest-onnx", export_root)
+        if (engine_root / ".complete").is_file():
+            update_symlink(model_root / "latest-engines", engine_root)
+
+    input_json = None
+    output_json = None
+    raw_output_json = None
+    profile_json = None
+    policy_source_option = policy_source_value = None
+    policy_prompts: list[str] = []
+    asr_audio = None
+    if need_infer:
+        if info.is_cosmos3_policy:
+            policy_source_option, policy_source_value, policy_prompts, payload = cosmos_policy_request(args, home)
+            input_json = run_root / "policy-input.json"
+            input_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        elif info.is_nemotron_asr:
+            asr_audio, payload = nemotron_asr_request(args, home)
+            input_json = run_root / "asr-input.json"
+            input_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        elif args.input_json:
+            input_json = validate_input_json(args.input_json)
+        else:
+            input_json = run_root / "input.json"
+            write_default_input(input_json, args, info, home)
+        default_output = "transcript.txt" if info.is_nemotron_asr else "output.json"
+        default_profile = "benchmark.txt" if info.is_cosmos3_policy or info.is_nemotron_asr else "profile.json"
+        output_json = (
+            args.output_json.expanduser().resolve()
+            if args.output_json
+            else run_root / default_output
+        )
+        profile_json = (
+            args.profile_json.expanduser().resolve()
+            if args.profile_json
+            else run_root / default_profile
+        )
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        profile_json.parent.mkdir(parents=True, exist_ok=True)
+
+    def require_engine(path: Path) -> None:
+        if not path.is_file() and not args.dry_run:
+            raise SystemExit(f"Missing engine artifact: {path}")
+
+    if need_infer:
+        assert input_json is not None and output_json is not None and profile_json is not None
+        runtime_capture = None
+        if info.is_cosmos3_policy:
+            assert policy_source_option and policy_source_value and policy_prompts
+            for component in ("und_prefill", "gen", "vae_encoder"):
+                require_engine(engine_root / component / f"{component}.engine")
+            command = [
+                str(binary["cosmos3_policy_inference"]),
+                "--engineDir", str(engine_root),
+                policy_source_option, policy_source_value,
+                "--output", str(output_json),
+                "--domain", args.policy_domain,
+                "--viewPoint", args.policy_viewpoint,
+                "--steps", str(args.policy_steps),
+                "--seed", str(args.policy_seed),
+                "--guidance", str(args.policy_guidance),
+                "--video-subsample-factor", str(args.policy_video_subsample_factor),
+                "--action-chunk-size", str(args.policy_action_chunk_size),
+                "--iters", "1",
+                "--warmup", str(args.inference_warmup),
+            ]
+            for prompt in policy_prompts:
+                command.extend(("--prompt", prompt))
+            command.extend(args.inference_arg)
+            runtime_capture = run_root / "inference.log"
+        elif info.is_nemotron_asr:
+            assert asr_audio is not None
+            asr_runtime_dir = engine_root / "runtime"
+            require_engine(asr_runtime_dir / "audio_encoder.engine")
+            require_engine(asr_runtime_dir / "rnnt_step.engine")
+            command = [
+                str(binary["nemotron_asr_inference"]),
+                "--engineDir", str(asr_runtime_dir),
+                "--audioFile", str(asr_audio),
+            ]
+            if args.asr_prompt_id is not None:
+                command.extend(("--promptId", str(args.asr_prompt_id)))
+            command.extend(args.inference_arg)
+            runtime_capture = output_json
+        elif info.is_tts:
+            require_engine(engine_root / "talker/llm.engine")
+            command = [
+                str(binary["qwen3_tts_inference"]), "--talkerEngineDir", str(engine_root / "talker"),
+                "--code2wavEngineDir", str(engine_root / "code2wav"), "--tokenizerDir", str(engine_root / "talker"),
+                "--inputFile", str(input_json), "--outputFile", str(output_json), "--outputAudioDir", str(run_root / "audio"),
+                "--dumpProfile", "--profileOutputFile", str(profile_json), "--dumpOutput", *args.inference_arg,
+            ]
+            if info.tts_mode == "base":
+                require_engine(engine_root / "clone_encoders/speaker_encoder.engine")
+                require_engine(engine_root / "clone_encoders/speech_tokenizer_encoder.engine")
+                command.extend(("--cloneEncoderDir", str(engine_root / "clone_encoders")))
+            if args.builder == "weightless":
+                command.extend(("--checkpointDir", str(base_path)))
+        elif info.has_action:
+            require_engine(llm_engine / "llm.engine")
+            command = [
+                str(binary["action_inference"]), "--engineDir", str(llm_engine), "--multimodalEngineDir", str(multimodal_engine),
+                "--inputFile", str(input_json), "--outputFile", str(output_json), "--warmup", str(args.inference_warmup),
+                "--dumpProfile", "--profileOutputFile", str(profile_json), "--dumpOutput", *args.inference_arg,
+            ]
+            if args.builder == "weightless":
+                command.extend(("--checkpointDir", str(base_path)))
+        else:
+            expected_llm = "spec_base.engine" if args.spec_mode != "none" else (
+                "dllm.engine" if info.is_diffusion else "llm.engine"
+            )
+            require_engine(llm_engine / expected_llm)
+            command = [
+                str(binary["llm_inference"]), "--engineDir", str(llm_engine), "--inputFile", str(input_json),
+                "--outputFile", str(output_json), "--warmup", str(args.inference_warmup), "--dumpProfile",
+                "--profileOutputFile", str(profile_json), "--dumpOutput",
+            ]
+            if args.builder == "weightless":
+                command.extend(("--checkpointDir", str(base_path)))
+                if draft_path:
+                    command.extend(("--draftCheckpointDir", str(draft_path)))
+            if info.has_visual or info.has_audio:
+                command.extend(("--multimodalEngineDir", str(multimodal_engine)))
+            if args.spec_mode != "none":
+                command.extend((
+                    "--specDecode", "--specDraftTopK", str(draft_top_k), "--specDraftStep", str(draft_steps),
+                    "--specVerifySize", str(verify_size),
+                ))
+                if args.dflash_block_size:
+                    command.extend(("--dflashBlockSize", str(args.dflash_block_size)))
+            if args.audio_output:
+                if not info.is_omni:
+                    raise SystemExit("--audio-output is only valid for Qwen3-Omni")
+                command.extend((
+                    "--enableAudioOutput", "--talkerEngineDir", str(engine_root / "talker"),
+                    "--code2wavEngineDir", str(engine_root / "code2wav"), "--outputAudioDir", str(run_root / "audio"),
+                ))
+            command.extend(args.inference_arg)
+        runner.run(command, home, capture_file=runtime_capture)
+        if not args.dry_run and not (info.is_cosmos3_policy or info.is_nemotron_asr):
+            raw_output_json = normalize_gemma4_output(
+                output_json, run_root / "output.raw.json", info.model_type
+            )
+            normalize_runtime_profile(profile_json, input_json, info)
+
+    layer_profile_requested = "--profile" in args.bench_arg
+    bench_args = [token for token in args.bench_arg if token != "--profile"]
+
+    def bench(mode: str, mode_args: list[str], directory: Path, engine_dir: Path = llm_engine) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        command_prefix = [
+            str(binary["llm_bench"]), "--engineDir", str(engine_dir), "--mode", mode,
+            "--batchSize", str(args.batch_size), "--warmup", str(args.bench_warmup),
+            "--iterations", str(args.bench_iterations), *mode_args, *bench_args,
+        ]
+        if args.builder == "weightless":
+            command_prefix.extend(("--checkpointDir", str(base_path)))
+            if draft_path:
+                command_prefix.extend(("--draftCheckpointDir", str(draft_path)))
+        runner.run([*command_prefix, "--outputDir", str(directory)], home)
+        if layer_profile_requested:
+            layer_directory = directory / "layers"
+            layer_directory.mkdir(parents=True, exist_ok=True)
+            runner.run([
+                *command_prefix, "--profile", "--outputDir", str(layer_directory),
+            ], home)
+
+    if need_bench and not info.is_tts:
+        bench_root = run_root / "bench"
+        bench_root.mkdir(parents=True, exist_ok=True)
+        if info.is_cosmos3_policy:
+            assert output_json is not None and profile_json is not None
+            assert policy_source_option and policy_source_value and policy_prompts
+            command = [
+                str(binary["cosmos3_policy_inference"]),
+                "--engineDir", str(engine_root),
+                policy_source_option, policy_source_value,
+                "--output", str(bench_root / "action.json"),
+                "--domain", args.policy_domain,
+                "--viewPoint", args.policy_viewpoint,
+                "--steps", str(args.policy_steps),
+                "--seed", str(args.policy_seed),
+                "--guidance", str(args.policy_guidance),
+                "--video-subsample-factor", str(args.policy_video_subsample_factor),
+                "--action-chunk-size", str(args.policy_action_chunk_size),
+                "--iters", str(args.bench_iterations),
+                "--warmup", str(args.bench_warmup),
+            ]
+            for prompt in policy_prompts:
+                command.extend(("--prompt", prompt))
+            command.extend(bench_args)
+            runner.run(command, home, capture_file=profile_json)
+            benchmark_summary = profile_json
+        elif info.is_nemotron_asr:
+            assert asr_audio is not None and profile_json is not None
+            asr_runtime_dir = engine_root / "runtime"
+            command = [
+                str(binary["nemotron_asr_inference"]),
+                "--engineDir", str(asr_runtime_dir),
+                "--audioFile", str(asr_audio),
+                "--benchmark",
+                "--iters", str(args.bench_iterations),
+                "--warmup", str(args.bench_warmup),
+            ]
+            if args.asr_prompt_id is not None:
+                command.extend(("--promptId", str(args.asr_prompt_id)))
+            command.extend(bench_args)
+            runner.run(command, home, capture_file=profile_json)
+            benchmark_summary = profile_json
+        else:
+            expected_llm = "spec_base.engine" if args.spec_mode != "none" else (
+                "dllm.engine" if info.is_diffusion else "llm.engine"
+            )
+            require_engine(llm_engine / expected_llm)
+        if args.spec_mode != "none":
+            print(
+                "Using the speculative runtime profile for end-to-end prefill and decode timing, "
+                "plus standalone base-verification and draft component benchmarks.",
+                flush=True,
+            )
+            spec_bench_args = [
+                "--draftStep", str(draft_steps),
+                "--verifyTreeSize", str(verify_size),
+            ]
+            bench("spec_verify", [
+                *spec_bench_args,
+                "--pastKVLen", str(past_kv_len),
+                "--osl", str(args.bench_output_len),
+            ], bench_root / "spec_verify")
+            bench("spec_draft_prefill", [
+                *spec_bench_args,
+                "--inputLen", str(prefill_len),
+            ], bench_root / "spec_draft_prefill")
+            bench("spec_draft_proposal", [
+                *spec_bench_args,
+                "--draftTreeSize", str(draft_top_k),
+                "--pastKVLen", str(past_kv_len),
+                "--osl", str(args.bench_output_len),
+            ], bench_root / "spec_draft_proposal")
+        elif runtime_profile_benchmark and not (info.is_cosmos3_policy or info.is_nemotron_asr):
+            print(
+                "Using the real model runtime for end-to-end timing; the standalone "
+                "LLM benchmark does not represent this model's generation contract.",
+                flush=True,
+            )
+        elif not (info.is_cosmos3_policy or info.is_nemotron_asr):
+            bench("prefill", ["--inputLen", str(prefill_len)], bench_root / "prefill")
+            bench("decode", ["--pastKVLen", str(past_kv_len), "--osl", str(args.bench_output_len)], bench_root / "decode")
+        if info.has_visual and not info.is_cosmos3_policy:
+            print(
+                "Using the real inference profile for vision timing; the standalone "
+                "visual benchmark creates HWC input instead of the runtime's THWC contract.",
+                flush=True,
+            )
+        if not args.dry_run and not (info.is_cosmos3_policy or info.is_nemotron_asr):
+            benchmark_summary = summarize_benchmarks(
+                bench_root,
+                run_root,
+                profile_json,
+                args.batch_size,
+                include_runtime_summary=runtime_profile_benchmark,
+            )
+
+    if need_server:
+        serve_options = {"host": args.host, "port": args.port}
+        if args.allowed_local_media_path:
+            allowed_media = Path(args.allowed_local_media_path).expanduser().resolve()
+            if not allowed_media.is_dir() and not args.dry_run:
+                raise SystemExit(
+                    f"--allowed-local-media-path is not a directory: {allowed_media}"
+                )
+            serve_options["allowed_local_media_path"] = str(allowed_media)
+
+        if info.is_tts:
+            talker_engine = engine_root / "talker"
+            code_predictor_engine = engine_root / "code_predictor"
+            code2wav_engine = engine_root / "code2wav"
+            require_engine(talker_engine / "llm.engine")
+            require_engine(code_predictor_engine / "llm.engine")
+            require_engine(code2wav_engine / "code2wav.engine")
+            tts_options = {
+                "talker_engine_dir": str(talker_engine),
+                "code_predictor_engine_dir": str(code_predictor_engine),
+                "code2wav_engine_dir": str(code2wav_engine),
+                "tokenizer_dir": str(talker_engine),
+                "model": args.model,
+            }
+            server_code = (
+                "from experimental.server import TTS; "
+                f"tts=TTS(**{tts_options!r}); "
+                f"tts.serve(host={args.host!r}, port={args.port})"
+            )
+            runner.run([sys.executable, "-c", server_code], home)
+        else:
+            expected_llm = "spec_base.engine" if args.spec_mode != "none" else "llm.engine"
+            require_engine(llm_engine / expected_llm)
+            llm_options = {
+                "engine_dir": str(llm_engine),
+                "draft_top_k": draft_top_k,
+                "draft_step": draft_steps,
+                "verify_tree_size": verify_size,
+            }
+            if (info.has_visual or info.has_audio) and args.spec_mode == "none" and not args.text_only:
+                if info.has_visual:
+                    require_engine(multimodal_engine / "visual/visual.engine")
+                if info.has_audio:
+                    require_engine(multimodal_engine / "audio/audio_encoder.engine")
+                llm_options["multimodal_engine_dir"] = str(multimodal_engine)
+            if info.model_type in PLE_MODEL_TYPES:
+                launcher = gemma4_server_launcher(model_root)
+                command = [
+                    sys.executable,
+                    str(launcher),
+                    json.dumps(llm_options),
+                    json.dumps(serve_options),
+                ]
+            else:
+                server_code = (
+                    "from experimental.server import LLM; "
+                    f"llm=LLM(**{llm_options!r}); "
+                    f"llm.serve(**{serve_options!r})"
+                )
+                command = [sys.executable, "-c", server_code]
+            runner.run(command, home)
+
+    manifest = {
+        "edge_llm_version": EXPECTED_VERSION,
+        "builder": args.builder,
+        "model": args.model,
+        "resolved_model": str(base_path),
+        "model_type": info.model_type,
+        "components": {
+            "llm": info.has_llm,
+            "visual": info.has_visual,
+            "audio": info.has_audio,
+            "talker": info.has_talker,
+            "code_predictor": info.has_code_predictor,
+            "code2wav": info.has_code2wav,
+            "action": info.has_action or info.is_cosmos3_policy,
+            "cosmos3_policy": info.is_cosmos3_policy,
+            "rnnt": info.is_nemotron_asr,
+        },
+        "requested_external_weights": list(
+            weightless_external_weights
+            if args.builder == "weightless"
+            else info.external_weights
+        ),
+        "externalized_weights": (
+            None
+            if args.builder == "weightless"
+            else list(info.external_weights)
+        ),
+        "external_weight_binding_source": (
+            "component config.json checkpoint bindings"
+            if args.builder == "weightless"
+            else "exported external-weight files"
+        ),
+        "speculative_decoding": {
+            "mode": args.spec_mode,
+            "draft_top_k": draft_top_k,
+            "draft_steps": draft_steps,
+            "verify_size": verify_size,
+            "dflash_block_size": args.dflash_block_size,
+        },
+        "onnx_dir": str(export_root) if args.builder == "onnx" else None,
+        "checkpoint_dir": str(base_path) if args.builder == "weightless" else None,
+        "engine_dir": str(engine_root),
+        "input_json": str(input_json) if input_json else None,
+        "output_json": str(output_json) if output_json else None,
+        "raw_output_json": str(raw_output_json) if raw_output_json else None,
+        "profile_json": str(profile_json) if profile_json else None,
+        "benchmark": {
+            "prefill_len": prefill_len,
+            "past_kv_len": past_kv_len,
+            "output_len": args.bench_output_len,
+            "summary": str(benchmark_summary) if benchmark_summary else None,
+        },
+        "commands": str(command_file),
+        "run_dir": str(run_root),
+    }
+    (run_root / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print("\nTensorRT Edge-LLM workflow complete")
+    print(f"  model type : {info.model_type}")
+    print(f"  builder    : {args.builder}")
+    if args.builder == "onnx":
+        print(f"  ONNX       : {export_root}")
+    print(f"  engines    : {engine_root}")
+    print(f"  run        : {run_root}")
+    print(f"  commands   : {command_file}")
+    if need_infer:
+        assert output_json is not None and profile_json is not None
+        print(f"  output     : {output_json}")
+        print(f"  profile    : {profile_json}")
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -43,7 +43,7 @@ const modelColors = allModels.map((_, i) =>
 	i === 0 ? MAIN_COLOR : (SERIES_COLORS[i - 1] ?? SERIES_COLORS[SERIES_COLORS.length - 1]),
 );
 
-const ENGINE_ORDER = ['vLLM', 'SGLang', 'llama.cpp', 'Ollama', 'Edge-LLM', 'TRT'];
+const ENGINE_ORDER = ['vLLM', 'SGLang', 'llama.cpp', 'Ollama', 'TensorRT Edge-LLM', 'TRT'];
 
 // Collect all engine names across all models, sorted by preferred order
 const engineNamesSet: string[] = [];
@@ -109,7 +109,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 	'SGLang':    '#d55816',
 	'llama.cpp': '#8899A6',
 	'Ollama':    '#2E2E2E',
-	'Edge-LLM':  '#006666',
+	'TensorRT Edge-LLM': '#006666',
 };
 ---
 
@@ -219,7 +219,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 		'SGLang':    '#d55816',
 		'llama.cpp': '#8899A6',
 		'Ollama':    '#2E2E2E',
-		'Edge-LLM':  '#006666',
+		'TensorRT Edge-LLM': '#006666',
 	};
 
 	const chartEl = document.getElementById('bench-chart');

--- a/src/components/RunCommand.astro
+++ b/src/components/RunCommand.astro
@@ -1,6 +1,6 @@
 ---
 import type { InferenceCategory } from '../lib/engines';
-import { enginesForCategory, defaultEngineForCategory } from '../lib/engines';
+import { defaultEngineForCategory } from '../lib/engines';
 import { sortEnginesForUi } from '../lib/modelFrontmatterAdapter';
 import {
 	applyMatrixModuleDisabledFlags,
@@ -8,7 +8,9 @@ import {
 	buildModuleCommandMatrix,
 	engineHasPlatformContent,
 	engineSupportsModule,
+	filterEnginesForModel,
 	matchSupportedEngine,
+	normalizeEngineKey,
 	type SupportedEngineEntry,
 	visibleModulesForEngines,
 	moduleIdToPlatformMap,
@@ -64,32 +66,19 @@ const {
 	oneShotInference = null,
 } = Astro.props as Props;
 
-let engines = enginesForCategory(category);
+let engines = filterEnginesForModel(category, supportedEngines);
 
-// Filter engines if supportedEngines is provided
 if (supportedEngines && supportedEngines.length > 0) {
-    const supportedIds = supportedEngines.map(e => e.engine.toLowerCase());
-    // Map markdown engine names (e.g., "Ollama", "vLLM") to engine IDs (e.g., "ollama", "vllm")
-    // Special handling for vLLM if needed, but toLowerCase usually works if IDs are lowercase
-    engines = engines.filter(e => supportedIds.includes(e.id) || supportedIds.includes(e.label.toLowerCase()));
-    
-    // If filtering resulted in empty list (mismatch), fall back to all category engines or handle error
-    if (engines.length === 0) {
-        // Fallback: try to find engines that match loosely
-         const allEngines = enginesForCategory(category);
-         engines = allEngines.filter(e => supportedIds.some(id => id.includes(e.id) || e.id.includes(id)));
-    }
-    const sortedYaml = sortEnginesForUi(supportedEngines as SupportedEngineEntry[]);
-    const rank = new Map<string, number>();
-    sortedYaml.forEach((se, i) => {
-      const k = se.engine.toLowerCase().replace(/[.\-_]/g, '');
-      rank.set(k, i);
-    });
-    engines = [...engines].sort((a, b) => {
-      const ka = a.id.replace(/[.\-_]/g, '');
-      const kb = b.id.replace(/[.\-_]/g, '');
-      return (rank.get(ka) ?? 99) - (rank.get(kb) ?? 99);
-    });
+	const sortedYaml = sortEnginesForUi(supportedEngines as SupportedEngineEntry[]);
+	const rank = new Map<string, number>();
+	sortedYaml.forEach((se, i) => {
+		rank.set(normalizeEngineKey(se.engine), i);
+	});
+	engines = [...engines].sort((a, b) => {
+		const ka = normalizeEngineKey(a.id);
+		const kb = normalizeEngineKey(b.id);
+		return (rank.get(ka) ?? 99) - (rank.get(kb) ?? 99);
+	});
 }
 
 const defaultEngine = defaultEngineForCategory(category);

--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -71,6 +71,23 @@ supported_inference_engines:
         -v $HOME/.cache/huggingface:/root/.cache/huggingface \
         ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
         llama-server -hf Kbenkhaled/Cosmos-Reason2-2B-GGUF:Q8_0 -c 8192
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -e HF_TOKEN="$HF_TOKEN" \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model cagataydev/cosmos-reason2-2b-fp8-hf --builder onnx --stage serve
 benchmark_key: "Cosmos Reasoning 2 2B"
 benchmark_series:
   - "Cosmos Reasoning 2 8B"

--- a/src/content/models/cosmos3-edge.md
+++ b/src/content/models/cosmos3-edge.md
@@ -46,6 +46,32 @@ supported_inference_engines:
           --trust-remote-code \
           --max-model-len 16384 \
           --gpu-memory-utilization 0.3
+  - engine: "TensorRT Edge-LLM"
+    type: "Container (reasoner; policy offline)"
+    modules_supported:
+      - thor_t5000
+      - thor_t4000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model nvidia/Cosmos3-Edge --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/Cosmos3-Edge --builder onnx --stage serve
   - engine: "vLLM-Omni"
     type: "Generator / Action"
     modules_supported:
@@ -70,6 +96,16 @@ benchmark_series:
 [Cosmos3 Edge](https://huggingface.co/nvidia/Cosmos3-Edge) is the edge-optimized member of the NVIDIA Cosmos3 family of omnimodal world models: a 2.4B multimodal reasoner paired with a diffusion-based generative tower (~4B total). It understands text, images, and video; generates images and video; and produces chunked robot action trajectories — designed for embedded deployment from Jetson Thor down to Jetson Orin-class devices.
 
 One checkpoint, two servers: the **vLLM** container serves the reasoner for text, image, and video understanding through the standard OpenAI chat API (it loads only the 2.4B reasoner from the full checkpoint — verified byte-identical to the standalone Cosmos3-Edge-Reasoner release), while the **vLLM-Omni** container serves generation and action through its videos API. Deploy either or both depending on your workload.
+
+TensorRT Edge-LLM 0.10.0 serves the reasoner through its experimental
+OpenAI-compatible server. Its Cosmos3 policy runtime is an offline
+image-and-instruction contract that writes an action chunk:
+
+```bash
+run-edgellm-model nvidia/Cosmos3-Edge-Policy-DROID \
+  --image /data/observation.jpg \
+  --prompt "Pick up the banana and place it in the bowl."
+```
 
 ## Key Capabilities
 

--- a/src/content/models/diffusiongemma-26b-a4b.md
+++ b/src/content/models/diffusiongemma-26b-a4b.md
@@ -1,18 +1,18 @@
 ---
 title: "DiffusionGemma 26B-A4B"
 model_id: "diffusiongemma-26b-a4b"
-short_description: "A diffusion language model with platform-specific NVFP4 and AWQ-INT4 checkpoints for Jetson Thor and Orin"
+short_description: "A block-diffusion multimodal model with platform-specific NVFP4 and AWQ-INT4 checkpoints for Jetson Thor and Orin"
 family: "Google Gemma4"
 icon: "💎"
 is_new: false
 order: 5
-type: "Text"
-vision_capable: false
+type: "Multimodal"
+vision_capable: true
 memory_requirements: "24GB RAM"
 precision: "NVFP4 / AWQ-INT4"
 parameters: "26B total / 4B active"
-modalities: ["Text"]
-context_length: "8K"
+modalities: ["Text", "Image", "Video"]
+context_length: "256K"
 hf_checkpoint: "nvidia/diffusiongemma-26B-A4B-it-NVFP4"
 huggingface_url: "https://huggingface.co/nvidia/diffusiongemma-26B-A4B-it-NVFP4"
 minimum_jetson: "AGX Orin"
@@ -28,13 +28,34 @@ serving:
         sudo docker run -it --rm --pull always --runtime=nvidia --network host vllm/vllm-openai:latest cyankiwi/diffusiongemma-26B-A4B-it-AWQ-INT4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser gemma4 --enable-auto-tool-choice --tool-call-parser gemma4 --default-chat-template-kwargs '{"enable_thinking":true}'
       serve_command_thor: >-
         sudo docker run -it --rm --pull always --runtime=nvidia --network host -e VLLM_USE_V2_MODEL_RUNNER=1 vllm/vllm-openai:latest nvidia/diffusiongemma-26B-A4B-it-NVFP4 --trust-remote-code --max-model-len 8192 --gpu-memory-utilization 0.7 --attention-backend TRITON_ATTN --reasoning-parser gemma4 --enable-auto-tool-choice --tool-call-parser gemma4 --default-chat-template-kwargs '{"enable_thinking":true}' --override-generation-config '{"max_new_tokens":null}'
+    - engine: "TensorRT Edge-LLM"
+      type: "Container (offline inference)"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model nvidia/diffusiongemma-26B-A4B-it-NVFP4 \
+            --builder onnx --stage all --no-benchmark
 ---
 
 DiffusionGemma 26B-A4B can be served on Jetson Thor with the official NVIDIA NVFP4 checkpoint and on Jetson Orin with an AWQ-INT4 checkpoint.
 
+TensorRT Edge-LLM 0.10.0 uses its model-specific block-diffusion executable;
+it does not expose this model through the generic HTTP server.
+
 ## Inputs and Outputs
 
-**Input:** Text
+**Input:** Text, image, or video
 
 **Output:** Text
 

--- a/src/content/models/gemma4-12b.md
+++ b/src/content/models/gemma4-12b.md
@@ -9,9 +9,9 @@ order: 2
 type: "Multimodal"
 vision_capable: true
 memory_requirements: "16GB RAM"
-precision: "NVFP4 / Q4_0 QAT GGUF"
+precision: "FP16 / NVFP4 / Q4_0 QAT GGUF"
 parameters: "12B"
-modalities: ["Text", "Image"]
+modalities: ["Text", "Image", "Audio"]
 context_length: "256K"
 license: "Apache 2.0"
 model_size: "10GB"
@@ -69,38 +69,55 @@ supported_inference_engines:
           --n-gpu-layers 999 \
           --port 8080 \
           --alias my_model
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -e HF_TOKEN="$HF_TOKEN" \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model google/gemma-4-12B-it --builder onnx --stage serve
 benchmark_key: "Gemma 4 12B"
 benchmark_series:
   - "Gemma 4 E2B"
   - "Gemma 4 26B-A4B"
 ---
 
-Gemma 4 12B is Google's mid-size dense Gemma 4 model — the step up from the edge-sized E2B/E4B variants for workloads that need stronger reasoning while fitting on a single Jetson. This page covers the **NVFP4** checkpoint for vLLM on Thor (efficient 4-bit inference on Blackwell) and Google's official **quantization-aware-trained Q4_0 GGUF** for llama.cpp on Thor and AGX Orin.
+Gemma 4 12B is Google's mid-size dense Gemma 4 model — the step up from the edge-sized E2B/E4B variants for workloads that need stronger reasoning while fitting on a single Jetson. This page covers FP16, NVFP4, and quantization-aware-trained Q4_0 deployment paths on Thor; the GGUF path also runs on AGX Orin.
 
 - Local assistants and RAG that outgrow the E-series models
-- Document, chart, and image understanding workloads
+- Document, chart, image, and audio understanding workloads
 - Coding help and repository Q&A on Thor- and Orin-class devices
 - General-purpose reasoning where MoE routing overhead isn't wanted
 
 ## Inputs and Outputs
 
-**Input:** Text and image
+**Input:** Text, images, and audio
 
 **Output:** Text
 
 ## Supported Platforms
 
-- Jetson Thor (vLLM NVFP4, llama.cpp GGUF)
+- Jetson Thor (TensorRT Edge-LLM FP16, vLLM NVFP4, llama.cpp GGUF)
 - Jetson AGX Orin 64GB (llama.cpp GGUF)
 
 ## Inference Engine
 
-This model is configured to run on Jetson with `vLLM` and `llama.cpp`.
+This model is configured to run on Jetson with `vLLM`, `llama.cpp`, and TensorRT Edge-LLM.
 
 ## Official Highlights
 
 - Google positions 12B as the **dense mid-size** option in the Gemma 4 family — a balance point between the edge-sized E2B/E4B and the frontier 26B-A4B/31B models.
-- Supports **256K context**, **text/image input**, and the Gemma 4 function-calling and long-context reasoning features.
+- Supports **256K context**, **text/image/audio input**, and the Gemma 4 function-calling and long-context reasoning features.
 - The official **QAT (quantization-aware trained) Q4_0** release preserves near-BF16 quality at 4-bit, making it the recommended GGUF for llama.cpp deployment.
 
 ## Gemma 4 Family

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -51,6 +51,48 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf unsloth/gemma-4-E2B-it-GGUF:Q4_K_S
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - orin_agx_64
+        - orin_nx_16
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -e HF_TOKEN="$HF_TOKEN" \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+          run-edgellm-model Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -e HF_TOKEN="$HF_TOKEN" \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+      run_commands_by_module:
+        orin_nx_16: |-
+          sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+            -e HF_TOKEN="$HF_TOKEN" \
+            -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+            -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+            -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+            -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+            ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+            run-edgellm-model Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ \
+              --builder onnx --stage serve \
+              --max-input-len 1152 --max-kv-cache-capacity 1280 \
+              --max-image-tokens 2048 --max-image-tokens-per-image 1024 \
+              --max-audio-time-steps 512
 benchmark_key: "Gemma 4 E2B"
 benchmark_series:
   - "Gemma 4 26B-A4B"
@@ -77,7 +119,7 @@ Gemma 4 E2B is the smallest variant in the Gemma 4 family. Google positions E2B 
 
 ## Inference Engine
 
-This model is configured to run on Jetson with `vLLM` and `llama.cpp`.
+This model is configured to run on Jetson with `vLLM`, `llama.cpp`, and TensorRT Edge-LLM.
 
 ## Official Highlights
 

--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -50,6 +50,33 @@ serving:
           -v $HOME/.cache/huggingface:/root/.cache/huggingface \
           ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
           llama-server -hf unsloth/gemma-4-E4B:Q4_K_M
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - orin_agx_64
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -e HF_TOKEN="$HF_TOKEN" \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+          run-edgellm-model Vishva007/gemma-4-E4B-it-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -e HF_TOKEN="$HF_TOKEN" \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model Vishva007/gemma-4-E4B-it-W4A16-AutoRound-GPTQ --builder onnx --stage serve
 benchmark_key: "Gemma 4 E4B"
 ---
 
@@ -73,7 +100,7 @@ Gemma 4 E4B is a lightweight Gemma 4 model that can be served locally on Jetson 
 
 ## Inference Engine
 
-This model is configured to run on Jetson with `vLLM` and `llama.cpp`.
+This model is configured to run on Jetson with `vLLM`, `llama.cpp`, and TensorRT Edge-LLM.
 
 ## Official Highlights
 

--- a/src/content/models/llama3-1-8b.md
+++ b/src/content/models/llama3-1-8b.md
@@ -9,7 +9,7 @@ order: 2
 type: "Text"
 vision_capable: false
 memory_requirements: "8GB RAM"
-precision: "W4A16"
+precision: "NVFP4 / W4A16"
 parameters: "8B"
 modalities: ["Text"]
 context_length: "128K"
@@ -58,6 +58,34 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -e HF_TOKEN="$HF_TOKEN" \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16 --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -e HF_TOKEN="$HF_TOKEN" \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/Llama-3.1-8B-Instruct-NVFP4 --builder onnx --stage serve
 one_shot_inference:
   modules_supported:
     - thor_t5000
@@ -69,8 +97,12 @@ one_shot_inference:
   run_command_thor: ollama run llama3.1:8b
 ---
 
-Meta's Llama 3.1 8B Instruct is a powerful instruction-tuned language model with 8 billion parameters. This quantized version (W4A16) provides excellent performance while being memory efficient for edge deployment on Jetson devices.
+Meta's Llama 3.1 8B Instruct is a powerful instruction-tuned language model with 8 billion parameters. Published W4A16 and NVFP4 checkpoints provide memory-efficient deployment on Jetson.
 
 The model excels at following instructions, answering questions, and generating coherent text across a wide range of tasks.
 
+## Inputs and Outputs
 
+**Input:** Text
+
+**Output:** Text

--- a/src/content/models/nemotron-3-nano-30b-a3b.md
+++ b/src/content/models/nemotron-3-nano-30b-a3b.md
@@ -45,6 +45,22 @@ serving:
         - orin_nano_8
       serve_command_orin: ollama pull nemotron-3-nano && ollama serve
       serve_command_thor: ollama pull nemotron-3-nano && ollama serve
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 --builder onnx --stage serve
 one_shot_inference:
   modules_supported:
     - thor_t5000

--- a/src/content/models/nemotron-3-nano-omni.md
+++ b/src/content/models/nemotron-3-nano-omni.md
@@ -70,6 +70,23 @@ supported_inference_engines:
       - orin_agx_64
     serve_command_thor: ollama run nemotron3:33b-q4_K_M
     serve_command_orin: ollama run nemotron3:33b-q4_K_M
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -e HF_TOKEN="$HF_TOKEN" \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 --builder onnx --stage serve
 benchmark_key: "Nemotron 3 Nano Omni"
 benchmark_series:
   - "Nemotron 3 30B-A3B"
@@ -173,156 +190,3 @@ Ollama runs the Q4_K_M GGUF directly on the GPU and works on both Jetson Thor an
 ```bash
 ollama run nemotron3:33b-q4_K_M
 ```
-
-## Running with TensorRT Edge-LLM
-
-TensorRT Edge-LLM support for this model is currently Jetson Thor only. It requires exporting the model to ONNX and building TensorRT engines before running inference. See the [TensorRT Edge-LLM GitHub repository](https://github.com/NVIDIA/TensorRT-Edge-LLM) and the [export/build quick start](https://nvidia.github.io/TensorRT-Edge-LLM/user_guide/getting_started/quick-start-guide.html) for the full setup flow.
-
-<details>
-<summary><strong>Steps for TensorRT-Edge-LLM on Jetson Thor</strong></summary>
-
-Run these steps on Jetson Thor. Set paths for the TensorRT Edge-LLM checkout, model checkpoint, ONNX export directory, and engine output directory:
-
-```bash
-export TRT_EDGE_LLM_REPO=$HOME/tensorrt-edge-llm
-export CHECKPOINT_DIR=/path/to/nemotron-nano-3-omni-checkpoint
-export WORKSPACE=$HOME/tensorrt-edgellm-workspace/nemotron-nano-3-omni
-export ONNX=$WORKSPACE/onnx
-export ENGINE=$WORKSPACE/engines
-```
-
-### Build TensorRT Edge-LLM
-
-```bash
-cd $HOME
-git clone https://github.com/NVIDIA/TensorRT-Edge-LLM.git tensorrt-edge-llm
-cd tensorrt-edge-llm
-git submodule update --init 3rdParty/nlohmannJson 3rdParty/NVTX
-
-mkdir -p build
-cd build
-export PATH=/usr/local/cuda/bin:$PATH
-
-cmake .. -DCMAKE_BUILD_TYPE=Release \
-  -DENABLE_CUTE_DSL=ALL \
-  -DTRT_PACKAGE_DIR=/usr \
-  -DCUDA_CTK_VERSION=13.0
-
-make -j$(nproc)
-```
-
-### Export ONNX
-
-```bash
-export PYTHONPATH=$TRT_EDGE_LLM_REPO/experimental:$PYTHONPATH
-python3 -m venv $HOME/trt-edgellm-venv
-source $HOME/trt-edgellm-venv/bin/activate
-
-cd $TRT_EDGE_LLM_REPO/experimental/llm_loader
-pip3 install -r requirements.txt
-
-python3 -m llm_loader.export_all_cli \
-  $CHECKPOINT_DIR \
-  $ONNX
-```
-
-This creates `$ONNX/llm`, `$ONNX/visual`, and `$ONNX/audio`.
-
-### Build Engines
-
-```bash
-export BUILD=$HOME/tensorrt-edge-llm/build
-export EDGELLM_PLUGIN_PATH=$BUILD/libNvInfer_edgellm_plugin.so
-export LD_PRELOAD=$EDGELLM_PLUGIN_PATH
-
-$BUILD/examples/llm/llm_build \
-  --onnxDir $ONNX/llm \
-  --engineDir $ENGINE/llm
-
-$BUILD/examples/multimodal/visual_build \
-  --onnxDir $ONNX/visual \
-  --engineDir $ENGINE/visual
-
-$BUILD/examples/multimodal/audio_build \
-  --onnxDir $ONNX/audio \
-  --engineDir $ENGINE/audio
-
-# Some builder versions emit nested modality directories. Flatten them if needed.
-[ -d "$ENGINE/visual/visual" ] && mv $ENGINE/visual/visual/* $ENGINE/visual/ && rmdir $ENGINE/visual/visual
-[ -d "$ENGINE/audio/audio" ] && mv $ENGINE/audio/audio/* $ENGINE/audio/ && rmdir $ENGINE/audio/audio
-```
-
-### Run Inference
-
-Use the same inference command for text, vision, and audio by changing the input and output JSON files:
-
-```bash
-$BUILD/examples/llm/llm_inference \
-  --engineDir $ENGINE/llm \
-  --multimodalEngineDir $ENGINE \
-  --inputFile <input.json> \
-  --outputFile <output.json> \
-  --dumpOutput
-```
-
-Text input:
-
-```json
-{
-  "requests": [
-    {
-      "messages": [
-        {"role": "user", "content": "What is 2+2?"}
-      ],
-      "max_generate_length": 50,
-      "temperature": 0.0
-    }
-  ]
-}
-```
-
-Vision input:
-
-```json
-{
-  "requests": [
-    {
-      "messages": [
-        {
-          "role": "user",
-          "content": [
-            {"type": "image", "image": "/path/to/image.jpg"},
-            {"type": "text", "text": "What do you see in this image?"}
-          ]
-        }
-      ],
-      "max_generate_length": 100,
-      "temperature": 0.0
-    }
-  ]
-}
-```
-
-Audio input uses a pre-computed mel-spectrogram `.safetensors` file shaped `[1, time_steps, 128]` with `float16` values:
-
-```json
-{
-  "requests": [
-    {
-      "messages": [
-        {
-          "role": "user",
-          "content": [
-            {"type": "audio", "audio": "/path/to/audio_mel.safetensors"},
-            {"type": "text", "text": "What did you hear in this audio?"}
-          ]
-        }
-      ],
-      "max_generate_length": 100,
-      "temperature": 0.0
-    }
-  ]
-}
-```
-
-</details>

--- a/src/content/models/nemotron-nano-9b-v2.md
+++ b/src/content/models/nemotron-nano-9b-v2.md
@@ -30,6 +30,22 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4 --builder onnx --stage serve
 benchmark_key: "Nemotron Nano 9B V2"
 benchmark_series:
   - "Nemotron 3 30B-A3B"
@@ -65,5 +81,3 @@ The model uses a hybrid architecture:
 English, German, Spanish, French, Italian, Japanese, and coding languages.
 
 *This model is ready for commercial use.*
-
-

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -122,6 +122,23 @@ serving:
             --top-p 0.95 \
             --host 0.0.0.0 \
             --port 8080
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 --builder onnx --stage serve
 ---
 
 NVIDIA Nemotron 3.5 Lightning is a fast, open-weight 30B Mixture-of-Experts model that activates only 3B parameters per token. It brings performance close to the much larger Nemotron 3 Super while remaining practical for local coding assistants, research agents, tool-calling workflows, and other always-on applications.

--- a/src/content/models/nemotron3-nano-4b.md
+++ b/src/content/models/nemotron3-nano-4b.md
@@ -49,6 +49,22 @@ supported_inference_engines:
           --ctx-size 8196 \
           --alias my_model \
           --n-gpu-layers 999
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8 --builder onnx --stage serve
 benchmark_key: "Nemotron3 Nano 4B"
 benchmark_series:
   - "Nemotron Nano 9B V2"
@@ -70,10 +86,9 @@ Nemotron3 Nano 4B is a compact NVIDIA language model that can be served locally 
 
 ## Inference Engine
 
-This model is currently configured for `llama.cpp` using the GGUF checkpoint `NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf`.
+This model is configured to run on Jetson with `llama.cpp` and TensorRT Edge-LLM.
 
 ## Notes
 
 - The provided command uses `--alias my_model`; you can change that alias to match your application if needed.
 - `--n-gpu-layers 999` keeps the full model on GPU when memory allows for best performance.
-

--- a/src/content/models/qwen3-30b-a3b.md
+++ b/src/content/models/qwen3-30b-a3b.md
@@ -9,7 +9,7 @@ order: 3
 type: "Text"
 vision_capable: false
 memory_requirements: "16GB RAM"
-precision: "W4A16"
+precision: "NVFP4 / W4A16"
 parameters: "30B total / 3.3B activated"
 modalities: ["Text"]
 context_length: "128K"
@@ -45,6 +45,31 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         RedHatAI/Qwen3-30B-A3B-quantized.w4a16
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Qwen/Qwen3-30B-A3B-GPTQ-Int4 --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/Qwen3-30B-A3B-NVFP4 --builder onnx --stage serve
 benchmark_key: "Qwen3-30B-A3B"
 benchmark_series:
   - "Qwen3-32B"
@@ -65,4 +90,3 @@ Qwen3 30B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3 fam
 - **Subject Matter Experts**: Fine-tuning for domain-specific expertise
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Translation**: High-quality translation between supported languages
-

--- a/src/content/models/qwen3-4b.md
+++ b/src/content/models/qwen3-4b.md
@@ -9,7 +9,7 @@ order: 1
 type: "Text"
 vision_capable: false
 memory_requirements: "4GB RAM"
-precision: "W4A16"
+precision: "NVFP4 / W4A16 / AWQ"
 parameters: "4B"
 modalities: ["Text"]
 context_length: "128K"
@@ -47,6 +47,33 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         RedHatAI/Qwen3-4B-quantized.w4a16
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Qwen/Qwen3-4B-AWQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model baseten/Qwen3-4B-NVFP4-PTQ --builder onnx --stage serve
 benchmark_key: "Qwen 3 4B"
 benchmark_series:
   - "Qwen 3 8B"
@@ -67,4 +94,3 @@ Qwen3 is Alibaba Cloud's latest generation of large language models, offering st
 - **Subject Matter Experts**: Fine-tuning for domain-specific expertise
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Translation**: High-quality translation between supported languages
-

--- a/src/content/models/qwen3-5-0-8b.md
+++ b/src/content/models/qwen3-5-0-8b.md
@@ -5,7 +5,7 @@ short_description: "Alibaba's compact Qwen3.5 vision-language model for lightwei
 family: "Alibaba Qwen3.5"
 icon: "🔮"
 is_new: false
-order: 5
+order: 6
 type: "Multimodal"
 vision_capable: true
 memory_requirements: "2GB RAM"
@@ -52,6 +52,33 @@ supported_inference_engines:
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model AxionML/Qwen3.5-0.8B-NVFP4 --builder onnx --stage serve
 ---
 
 Qwen3.5 0.8B is the smallest vision-language model in the Qwen3.5 lineup. It is designed for lightweight local multimodal inference, fast iteration, and efficient Jetson deployment.

--- a/src/content/models/qwen3-5-27b.md
+++ b/src/content/models/qwen3-5-27b.md
@@ -1,13 +1,13 @@
 ---
 title: "Qwen3.5 27B"
 model_id: "qwen3-5-27b"
-short_description: "Alibaba's dense 27 billion parameter language model with native tool calling and MTP speculative decoding"
+short_description: "Alibaba's dense 27B vision-language model with native tool calling and MTP speculative decoding"
 family: "Alibaba Qwen3.5"
 icon: "🔮"
 is_new: false
 order: 2
-type: "Text"
-vision_capable: false
+type: "Multimodal"
+vision_capable: true
 memory_requirements: "18GB RAM"
 precision: "NVFP4 / W4A16"
 parameters: "27B"
@@ -50,6 +50,31 @@ supported_inference_engines:
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model QuantTrio/Qwen3.5-27B-AWQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model txn545/Qwen3.5-27B-NVFP4 --builder onnx --stage serve
 benchmark:
   orin:
     concurrency1: 9
@@ -64,17 +89,18 @@ benchmark_series:
   - "Qwen3.5-35B-A3B"
 ---
 
-Qwen3.5 27B is a dense language model from Alibaba Cloud's Qwen3.5 family. With 27 billion parameters, it delivers strong performance across complex reasoning, coding, and language understanding tasks.
+Qwen3.5 27B is a dense vision-language model from Alibaba Cloud's Qwen3.5 family. With 27 billion parameters, it combines visual understanding with complex reasoning, coding, and language tasks.
 
 ## Inputs and Outputs
 
-**Input:** Text
+**Input:** Text and images
 
 **Output:** Text
 
 ## Intended Use Cases
 
 - **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Visual understanding**: Image description, question answering, and document analysis
 - **Function Calling**: Native support for tool use and function calling
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Code Generation**: Programming assistance in multiple languages

--- a/src/content/models/qwen3-5-2b.md
+++ b/src/content/models/qwen3-5-2b.md
@@ -1,0 +1,70 @@
+---
+title: "Qwen3.5 2B"
+model_id: "qwen3-5-2b"
+short_description: "Alibaba's compact 2B vision-language model for multimodal inference on Jetson"
+family: "Alibaba Qwen3.5"
+icon: "🔮"
+is_new: false
+order: 5
+type: "Multimodal"
+vision_capable: true
+memory_requirements: "3GB RAM"
+precision: "NVFP4 / AWQ"
+parameters: "2B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
+model_size: "1.5GB"
+hf_checkpoint: "Qwen/Qwen3.5-2B"
+huggingface_url: "https://huggingface.co/Qwen/Qwen3.5-2B"
+minimum_jetson: "Orin Nano"
+supported_inference_engines:
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model QuantTrio/Qwen3.5-2B-AWQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model AxionML/Qwen3.5-2B-NVFP4 --builder onnx --stage serve
+---
+
+Qwen3.5 2B combines compact deployment with text and image understanding.
+
+## Inputs and Outputs
+
+**Input:** Text and images
+
+**Output:** Text
+
+## Intended Use Cases
+
+- **Visual question answering**: Ask questions about local images
+- **Image understanding**: Caption and analyze scenes
+- **Multilingual tasks**: Run compact multilingual assistants
+- **Local applications**: Build low-memory multimodal services
+
+## Additional Resources
+
+- [Original Model](https://huggingface.co/Qwen/Qwen3.5-2B)
+- [AWQ Checkpoint](https://huggingface.co/QuantTrio/Qwen3.5-2B-AWQ)
+- [NVFP4 Checkpoint](https://huggingface.co/AxionML/Qwen3.5-2B-NVFP4)

--- a/src/content/models/qwen3-5-35b-a3b.md
+++ b/src/content/models/qwen3-5-35b-a3b.md
@@ -1,13 +1,13 @@
 ---
 title: "Qwen3.5 35B-A3B (MoE)"
 model_id: "qwen3-5-35b-a3b"
-short_description: "Alibaba's latest Mixture-of-Experts model with 35B total / 3B active parameters, featuring native tool calling and MTP speculative decoding"
+short_description: "Alibaba's multimodal Mixture-of-Experts model with 35B total / 3B active parameters, native tool calling, and MTP speculative decoding"
 family: "Alibaba Qwen3.5"
 icon: "🔮"
 is_new: false
 order: 1
-type: "Text"
-vision_capable: false
+type: "Multimodal"
+vision_capable: true
 memory_requirements: "20GB RAM"
 precision: "NVFP4 / W4A16"
 parameters: "35B total / 3B activated"
@@ -50,6 +50,31 @@ supported_inference_engines:
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model AxionML/Qwen3.5-35B-A3B-NVFP4 --builder onnx --stage serve
 benchmark:
   orin:
     concurrency1: 30
@@ -64,17 +89,18 @@ benchmark_series:
   - "Qwen3.5-27B"
 ---
 
-Qwen3.5 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.5 family. It features 35 billion total parameters with only 3 billion active during inference, delivering strong performance with excellent efficiency on edge devices.
+Qwen3.5 35B-A3B is a multimodal Mixture-of-Experts model from Alibaba Cloud's Qwen3.5 family. It combines image understanding with 35 billion total parameters and only 3 billion active during inference.
 
 ## Inputs and Outputs
 
-**Input:** Text
+**Input:** Text and images
 
 **Output:** Text
 
 ## Intended Use Cases
 
 - **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Visual understanding**: Image description, question answering, and document analysis
 - **Function Calling**: Native support for tool use and function calling
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Code Generation**: Programming assistance in multiple languages
@@ -136,4 +162,5 @@ This model supports **Multi-Token Prediction (MTP)** speculative decoding, which
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) - Original model weights
 - [NVFP4 Checkpoint (Thor)](https://huggingface.co/AxionML/Qwen3.5-35B-A3B-NVFP4) - Quantized for Jetson Thor
+- [GPTQ INT4 Checkpoint (Orin)](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-GPTQ-Int4) - Quantized for Jetson AGX Orin
 - [W4A16 Checkpoint (Orin)](https://huggingface.co/Kbenkhaled/Qwen3.5-35B-A3B-quantized.w4a16) - Quantized for Jetson Orin

--- a/src/content/models/qwen3-5-4b.md
+++ b/src/content/models/qwen3-5-4b.md
@@ -32,6 +32,33 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest RedHatAI/Qwen3.5-4B-quantized.w4a16 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'
     serve_command_thor: >-
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest AxionML/Qwen3.5-4B-NVFP4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model vastai-ais/Qwen3.5-4B-AutoRound-GPTQ-Int4 --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model AxionML/Qwen3.5-4B-NVFP4 --builder onnx --stage serve
 benchmark_key: "Qwen3.5-4B"
 ---
 
@@ -54,4 +81,5 @@ Qwen3.5 4B offers a balanced point in the Qwen3.5 family for local multimodal in
 
 - [Original Model](https://huggingface.co/Qwen/Qwen3.5-4B) - Base Qwen3.5 4B checkpoint
 - [W4A16 Checkpoint](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w4a16) - Jetson Orin checkpoint
+- [GPTQ INT4 Checkpoint](https://huggingface.co/vastai-ais/Qwen3.5-4B-AutoRound-GPTQ-Int4) - Jetson Orin checkpoint
 - [NVFP4 Checkpoint](https://huggingface.co/AxionML/Qwen3.5-4B-NVFP4) - Jetson Thor checkpoint

--- a/src/content/models/qwen3-5-9b.md
+++ b/src/content/models/qwen3-5-9b.md
@@ -31,6 +31,31 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest RedHatAI/Qwen3.5-9B-quantized.w4a16 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'
     serve_command_thor: >-
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest AxionML/Qwen3.5-9B-NVFP4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Vishva007/Qwen3.5-9B-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model AxionML/Qwen3.5-9B-NVFP4 --builder onnx --stage serve
 benchmark_key: "Qwen3.5-9B"
 ---
 

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -1,15 +1,17 @@
 ---
 title: "Qwen3.6 27B"
 model_id: "qwen3-6-27b"
-short_description: "Alibaba's dense 27 billion parameter language model with native tool calling and MTP speculative decoding"
+short_description: "Alibaba's dense 27B vision-language model with native tool calling and MTP speculative decoding"
 family: "Alibaba Qwen3.6"
 icon: "🔮"
 is_new: false
 order: 2
-type: "Text"
-vision_capable: false
+type: "Multimodal"
+vision_capable: true
 memory_requirements: "18GB RAM"
 precision: "NVFP4 / AWQ-INT4"
+parameters: "27B"
+modalities: ["Text", "Image"]
 model_size: "19GB"
 hf_checkpoint: "Qwen/Qwen3.6-27B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-27B"
@@ -25,6 +27,31 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest cyankiwi/Qwen3.6-27B-AWQ-INT4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'
     serve_command_thor: >-
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest nvidia/Qwen3.6-27B-NVFP4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model QuantTrio/Qwen3.6-27B-AWQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model natfii/Qwen3.6-27B-VLM-NVFP4-MTP --mtp --builder onnx --stage serve
 benchmark:
   thor:
     concurrency1: 13
@@ -33,17 +60,18 @@ benchmark:
 benchmark_key: "Qwen3.6-27B"
 ---
 
-Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 27 billion parameters, it delivers strong performance across complex reasoning, coding, and language understanding tasks.
+Qwen3.6 27B is a dense vision-language model from Alibaba Cloud's Qwen3.6 family. With 27 billion parameters, it combines visual understanding with complex reasoning, coding, and language tasks.
 
 ## Inputs and Outputs
 
-**Input:** Text
+**Input:** Text and images
 
 **Output:** Text
 
 ## Intended Use Cases
 
 - **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Visual understanding**: Image description, question answering, and document analysis
 - **Function Calling**: Native support for tool use and function calling
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Code Generation**: Programming assistance in multiple languages
@@ -78,4 +106,6 @@ Both platform commands enable native **Multi-Token Prediction (MTP-3)** speculat
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-27B) - Original model weights
 - [NVFP4 Checkpoint (Thor)](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4) - Quantized for Jetson Thor
+- [NVFP4 + MTP Checkpoint (Thor)](https://huggingface.co/natfii/Qwen3.6-27B-VLM-NVFP4-MTP) - Includes a compatible quantized MTP head
 - [AWQ-INT4 Checkpoint (Orin)](https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4) - Quantized for Jetson Orin
+- [AWQ Checkpoint (Orin)](https://huggingface.co/QuantTrio/Qwen3.6-27B-AWQ) - Quantized for Jetson AGX Orin

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -1,15 +1,17 @@
 ---
 title: "Qwen3.6 35B-A3B (MoE)"
 model_id: "qwen3-6-35b-a3b"
-short_description: "Alibaba's latest Mixture-of-Experts model with 35B total / 3B active parameters, featuring native tool calling and MTP speculative decoding"
+short_description: "Alibaba's multimodal Mixture-of-Experts model with 35B total / 3B active parameters, native tool calling, and MTP speculative decoding"
 family: "Alibaba Qwen3.6"
 icon: "🔮"
 is_new: false
 order: 1
-type: "Text"
-vision_capable: false
+type: "Multimodal"
+vision_capable: true
 memory_requirements: "20GB RAM"
-precision: "NVFP4 / AWQ-4bit"
+precision: "NVFP4 / GPTQ-Int4 / AWQ-4bit"
+parameters: "35B total / 3B activated"
+modalities: ["Text", "Image"]
 model_size: "24GB"
 hf_checkpoint: "Qwen/Qwen3.6-35B-A3B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
@@ -25,6 +27,31 @@ supported_inference_engines:
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_coder --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'
     serve_command_thor: >-
       sudo docker run -it --rm --pull always --runtime=nvidia --network host -v ~/.cache/huggingface:/root/.cache/huggingface -v ~/.cache/vllm:/root/.cache/vllm vllm/vllm-openai:latest nvidia/Qwen3.6-35B-A3B-NVFP4 --max-model-len 8192 --gpu-memory-utilization 0.7 --reasoning-parser qwen3 --enable-auto-tool-choice --tool-call-parser qwen3_xml --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4 --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model ykarout/Qwen3.6-35B-A3B-NVFP4 --builder onnx --stage serve
 benchmark:
   orin:
     concurrency1: 30
@@ -37,17 +64,18 @@ benchmark:
 benchmark_key: "Qwen3.6-35B-A3B"
 ---
 
-Qwen3.6 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.6 family. It features 35 billion total parameters with only 3 billion active during inference, delivering strong performance with excellent efficiency on edge devices.
+Qwen3.6 35B-A3B is a multimodal Mixture-of-Experts model from Alibaba Cloud's Qwen3.6 family. It combines image understanding with 35 billion total parameters and only 3 billion active during inference.
 
 ## Inputs and Outputs
 
-**Input:** Text
+**Input:** Text and images
 
 **Output:** Text
 
 ## Intended Use Cases
 
 - **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Visual understanding**: Image description, question answering, and document analysis
 - **Function Calling**: Native support for tool use and function calling
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Code Generation**: Programming assistance in multiple languages
@@ -91,4 +119,6 @@ Both platform commands enable native **Multi-Token Prediction (MTP-3)** speculat
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) - Original model weights
 - [NVFP4 Checkpoint (Thor)](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4) - Official NVIDIA checkpoint for Jetson Thor
+- [NVFP4 Checkpoint (Thor)](https://huggingface.co/ykarout/Qwen3.6-35B-A3B-NVFP4) - Quantized for Jetson Thor
+- [GPTQ INT4 Checkpoint (Orin)](https://huggingface.co/palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4) - Quantized for Jetson AGX Orin
 - [AWQ Checkpoint (Orin)](https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit) - Quantized for Jetson Orin

--- a/src/content/models/qwen3-8-27b.md
+++ b/src/content/models/qwen3-8-27b.md
@@ -60,6 +60,23 @@ serving:
             --min-p 0.0 \
             --host 0.0.0.0 \
             --port 8080
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+        chmod +x "$HOME/run-edgellm-model"
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+          -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+          -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+          -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+          -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+          ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+          run-edgellm-model Inferact/Qwen3.8-27B-NVFP4 \
+            --builder onnx --stage serve
 ---
 
 Qwen3.8 27B is Qwen's dense, open-weight vision-language model for coding, professional work, research, and long-horizon agentic tasks. It brings the strongest generation of Qwen open models to a deployment-friendly size, with better planning and stronger handling of tool and environment feedback for more reliable multi-step task completion.
@@ -71,3 +88,18 @@ Thinking is enabled by default and can be disabled per request. Reasoning depth 
 Input: Text, image, and video
 
 Output: Text
+
+## TensorRT Edge-LLM
+
+The TensorRT Edge-LLM command uses a public ModelOpt NVFP4 checkpoint and
+serves text, image, and video requests. Native MTP is available as an explicit
+text-only server mode by adding `--mtp` to the `run-edgellm-model` command.
+
+The official fine-grained FP8 checkpoint is not a compatible 0.10.0 input;
+use the ModelOpt NVFP4 checkpoint shown above instead.
+
+## Additional Resources
+
+- [Original checkpoint](https://huggingface.co/Qwen/Qwen3.8-27B)
+- [ModelOpt NVFP4 checkpoint](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4)
+- [Official FP8 checkpoint](https://huggingface.co/Qwen/Qwen3.8-27B-FP8)

--- a/src/content/models/qwen3-8b.md
+++ b/src/content/models/qwen3-8b.md
@@ -9,7 +9,7 @@ order: 2
 type: "Text"
 vision_capable: false
 memory_requirements: "8GB RAM"
-precision: "W4A16"
+precision: "NVFP4 / W4A16 / GPTQ-Int4"
 parameters: "8B"
 modalities: ["Text"]
 context_length: "128K"
@@ -46,6 +46,32 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         RedHatAI/Qwen3-8B-quantized.w4a16
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model kaitchup/Qwen3-8B-autoround-4bit-gptq --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model nvidia/Qwen3-8B-NVFP4 --builder onnx --stage serve
 benchmark_key: "Qwen 3 8B"
 benchmark_series:
   - "Qwen 3 4B"
@@ -66,4 +92,3 @@ Qwen3 8B is a more powerful variant in Alibaba Cloud's latest generation of larg
 - **Subject Matter Experts**: Fine-tuning for domain-specific expertise
 - **Multilingual Instruction Following**: Following instructions across 100+ languages
 - **Translation**: High-quality translation between supported languages
-

--- a/src/content/models/qwen3-vl-2b.md
+++ b/src/content/models/qwen3-vl-2b.md
@@ -1,0 +1,70 @@
+---
+title: "Qwen3 VL 2B"
+model_id: "qwen3-vl-2b"
+short_description: "Alibaba's compact 2B vision-language model for image understanding on Jetson"
+family: "Alibaba Qwen3"
+icon: "🔮"
+is_new: false
+order: 5
+type: "Multimodal"
+vision_capable: true
+memory_requirements: "3GB RAM"
+precision: "NVFP4 / W4A16"
+parameters: "2B"
+modalities: ["Text", "Image"]
+context_length: "256K"
+license: "Apache 2.0"
+model_size: "1.5GB"
+hf_checkpoint: "Qwen/Qwen3-VL-2B-Instruct"
+huggingface_url: "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct"
+minimum_jetson: "Orin Nano"
+supported_inference_engines:
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Vishva007/Qwen3-VL-2B-Instruct-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model cybermotaz/qwen3-vl-2b-thinking-nvfp4-w4a16 --builder onnx --stage serve
+---
+
+Qwen3 VL 2B provides compact text and image understanding for memory-constrained Jetson deployments.
+
+## Inputs and Outputs
+
+**Input:** Text and images
+
+**Output:** Text
+
+## Intended Use Cases
+
+- **Visual question answering**: Answer questions about images
+- **Image understanding**: Describe scenes and objects
+- **Document analysis**: Extract and reason over visible content
+- **Local assistants**: Serve multimodal conversations on-device
+
+## Additional Resources
+
+- [Original Model](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct)
+- [W4A16 Checkpoint](https://huggingface.co/Vishva007/Qwen3-VL-2B-Instruct-W4A16-AutoRound-GPTQ)
+- [NVFP4 Thinking Checkpoint](https://huggingface.co/cybermotaz/qwen3-vl-2b-thinking-nvfp4-w4a16)

--- a/src/content/models/qwen3-vl-4b.md
+++ b/src/content/models/qwen3-vl-4b.md
@@ -5,11 +5,11 @@ short_description: "Alibaba's 4 billion parameter vision-language model for mult
 family: "Alibaba Qwen3"
 icon: "🔮"
 is_new: false
-order: 5
+order: 6
 type: "Multimodal"
 vision_capable: true
 memory_requirements: "6GB RAM"
-precision: "AWQ 4-bit"
+precision: "NVFP4 / W4A16 / AWQ"
 parameters: "4B"
 modalities: ["Text", "Image"]
 context_length: "256K"
@@ -37,6 +37,33 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         cpatonn/Qwen3-VL-4B-Instruct-AWQ-4bit
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+      - orin_nano_8
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Vishva007/Qwen3-VL-4B-Instruct-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model cybermotaz/qwen3-vl-4b-thinking-nvfp4-w4a16 --builder onnx --stage serve
 benchmark_key: "Qwen3-VL-4B"
 benchmark_series:
   - "Qwen3-VL-8B"
@@ -47,6 +74,12 @@ Meet Qwen3-VL — the most powerful vision-language model in the Qwen series to 
 This generation delivers comprehensive upgrades across the board: superior text understanding & generation, deeper visual perception & reasoning, extended context length, enhanced spatial and video dynamics comprehension, and stronger agent interaction capabilities.
 
 Available in Dense and MoE architectures that scale from edge to cloud, with Instruct and reasoning-enhanced Thinking editions for flexible, on-demand deployment.
+
+## Inputs and Outputs
+
+**Input:** Text and images
+
+**Output:** Text
 
 ## Key Enhancements
 
@@ -61,3 +94,7 @@ Available in Dense and MoE architectures that scale from edge to cloud, with Ins
 
 *Referenced from the [Qwen3-VL model card](https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct).*
 
+## Additional Resources
+
+- [W4A16 Checkpoint](https://huggingface.co/Vishva007/Qwen3-VL-4B-Instruct-W4A16-AutoRound-GPTQ)
+- [NVFP4 Thinking Checkpoint](https://huggingface.co/cybermotaz/qwen3-vl-4b-thinking-nvfp4-w4a16)

--- a/src/content/models/qwen3-vl-8b.md
+++ b/src/content/models/qwen3-vl-8b.md
@@ -5,11 +5,11 @@ short_description: "Alibaba's 8 billion parameter vision-language model for adva
 family: "Alibaba Qwen3"
 icon: "🔮"
 is_new: false
-order: 6
+order: 7
 type: "Multimodal"
 vision_capable: true
 memory_requirements: "8GB RAM"
-precision: "AWQ 4-bit"
+precision: "NVFP4 / W4A16 / AWQ"
 parameters: "8B"
 modalities: ["Text", "Image"]
 context_length: "256K"
@@ -36,6 +36,32 @@ supported_inference_engines:
         --runtime=nvidia --network host \
         vllm/vllm-openai:latest \
         cpatonn/Qwen3-VL-8B-Instruct-AWQ-4bit
+  - engine: "TensorRT Edge-LLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - orin_agx_64
+      - orin_nx_16
+    install_command: |-
+      mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+      curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh -o "$HOME/run-edgellm-model"
+      chmod +x "$HOME/run-edgellm-model"
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+        run-edgellm-model Vishva007/Qwen3-VL-8B-Instruct-W4A16-AutoRound-GPTQ --builder onnx --stage serve
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+        -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+        -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+        -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+        -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+        ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+        run-edgellm-model cybermotaz/qwen3-vl-8b-thinking-nvfp4-w4a16 --builder onnx --stage serve
 benchmark_key: "Qwen3-VL-8B"
 benchmark_series:
   - "Qwen3-VL-4B"
@@ -46,6 +72,12 @@ Meet Qwen3-VL — the most powerful vision-language model in the Qwen series to 
 This generation delivers comprehensive upgrades across the board: superior text understanding & generation, deeper visual perception & reasoning, extended context length, enhanced spatial and video dynamics comprehension, and stronger agent interaction capabilities.
 
 Available in Dense and MoE architectures that scale from edge to cloud, with Instruct and reasoning-enhanced Thinking editions for flexible, on-demand deployment.
+
+## Inputs and Outputs
+
+**Input:** Text and images
+
+**Output:** Text
 
 ## Key Enhancements
 
@@ -60,3 +92,7 @@ Available in Dense and MoE architectures that scale from edge to cloud, with Ins
 
 *Referenced from the [Qwen3-VL model card](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct).*
 
+## Additional Resources
+
+- [W4A16 Checkpoint](https://huggingface.co/Vishva007/Qwen3-VL-8B-Instruct-W4A16-AutoRound-GPTQ)
+- [NVFP4 Thinking Checkpoint](https://huggingface.co/cybermotaz/qwen3-vl-8b-thinking-nvfp4-w4a16)

--- a/src/content/tutorials/model-optimization/tensorrt-edge-llm.mdx
+++ b/src/content/tutorials/model-optimization/tensorrt-edge-llm.mdx
@@ -1,10 +1,10 @@
 ---
 title: "TensorRT Edge-LLM on Jetson"
-description: "Use NVIDIA TensorRT Edge-LLM with two example models: Cosmos Reason2 8B (VLM) on Jetson Thor and Qwen3-4B-Instruct (LLM) on Jetson Orin Nano. Covers quantization, ONNX export, TensorRT engine builds, and pure C++ on-device inference. The SDK supports Llama, Qwen3/3.5/3.6, InternVL3/3.5, Phi-4-Multimodal, Nemotron-Nano, Alpamayo R1, and more."
+description: "Download a published Hugging Face checkpoint, build every TensorRT engine, run offline inference and benchmarks, or launch a server with TensorRT Edge-LLM 0.10.0 on Jetson."
 category: "Model Optimization"
 section: "Edge LLM"
 order: 1
-tags: ["edge-llm", "tensorrt", "cosmos-reason2", "qwen3", "qwen3.5", "internvl3", "phi-4-multimodal", "nemotron-nano", "int4", "nvfp4", "quantization", "jetson-thor", "jetson-orin-nano", "vlm", "llm", "memory-optimization", "onnx", "c++"]
+tags: ["edge-llm", "tensorrt", "hugging-face", "jetson-thor", "jetson-orin", "vlm", "llm", "onnx", "c++", "direct-builder"]
 featured: false
 isNew: true
 authors:
@@ -12,934 +12,638 @@ authors:
     github: "adsahu-nv"
 ---
 
-import Tabs from '../../../components/Tabs.astro';
-
 # TensorRT Edge-LLM on Jetson
 
-[TensorRT Edge-LLM](https://github.com/NVIDIA/TensorRT-Edge-LLM) is NVIDIA's high-performance **C++ inference runtime** for LLMs and VLMs on embedded platforms. The workflow compiles trained models into optimized TensorRT engines; at run time, a small native binary loads those engines and serves requests with **no Python interpreter in the inference path**. Quantization (INT4, NVFP4, FP8) reduces weight footprint so larger models remain practical on memory-constrained devices. The SDK supports a wide range of models; see the full [Supported Models](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/docs/source/user_guide/getting_started/supported-models.md) list.
+[TensorRT Edge-LLM](https://github.com/NVIDIA/TensorRT-Edge-LLM) builds TensorRT
+engines for every component of a supported Hugging Face checkpoint and runs
+them through model-appropriate C++ runtimes. The supported path exports ONNX
+before building; 0.10.0 also includes an experimental weightless builder that
+compiles checkpoint-backed engines without ONNX. This page targets the 0.10.0 container and
+the release-specific [supported model and checkpoint list](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/release/0.10.0/docs/source/user_guide/getting_started/supported-models.md).
 
-## Overview
+The Jetson AI Lab workflow uses only published Hugging Face checkpoints. It
+does **not** run a quantizer or create a new quantized checkpoint. When a model
+needs INT4, GPTQ, FP8, or NVFP4, the command names an already-published
+checkpoint in that format.
 
-Edge-LLM supports a wide range of LLMs and VLMs across the entire Jetson family, from Orin Nano to Thor. See the full [Supported Models](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/docs/source/user_guide/getting_started/supported-models.md) list. In this tutorial, we walk through two examples that showcase the spectrum:
+## Quick Start
 
-| Model | Type | Parameters | Quantization | Target Device |
-|-------|------|------------|-------------|---------------|
-| [Cosmos-Reason2-8B](https://huggingface.co/nvidia/Cosmos-Reason2-8B) | VLM | 8B | NVFP4 | Jetson Thor |
-| [Qwen3-4B-Instruct](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507) | LLM | 4B | INT4 AWQ | Jetson Orin Nano 8 GB |
-
-Beyond these two examples, the same export → build → inference workflow applies to the full range of supported model families:
-
-<div style="overflow-x: auto; margin: 1rem 0 2rem;">
-<table style="width: 100%; border-collapse: collapse; font-size: 0.9rem; border: 1px solid #e2e8f0; border-radius: 0.5rem; overflow: hidden;">
-<thead>
-<tr style="background: #e2e8f0; color: #1e293b;">
-<th style="padding: 10px 14px; text-align: left; font-weight: 600;">Model Family</th>
-<th style="padding: 10px 14px; text-align: left; font-weight: 600;">Type</th>
-<th style="padding: 10px 14px; text-align: left; font-weight: 600;">Jetson Orin</th>
-<th style="padding: 10px 14px; text-align: left; font-weight: 600;">Jetson Thor</th>
-</tr>
-</thead>
-<tbody>
-<tr style="background: #f8fafc;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Llama 3.x Instruct</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">LLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Qwen3 dense (0.6B–14B)</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">LLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Qwen3.5 / Qwen3.6 text (0.8B–27B)</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">LLM / VLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Qwen3-VL (2B–8B)</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">VLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">InternVL3 / InternVL3.5 (1B–14B)</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">VLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 AWQ</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Phi-4-Multimodal</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">VLM</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">FP16 · INT4 · NVFP4</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600;">Nemotron-Nano 4B / 9B</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">LLM (Mamba2+Attention)</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">BF16</td><td style="padding: 10px 14px; border-bottom: 1px solid #e2e8f0;">BF16 · FP8 · NVFP4</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 10px 14px; font-weight: 600;">Alpamayo R1</td><td style="padding: 10px 14px;">VLA (robotics)</td><td style="padding: 10px 14px;">FP16</td><td style="padding: 10px 14px;">FP16</td></tr>
-</tbody>
-</table>
-</div>
-
-The workflow:
-
-<div class="mermaid-diagram">
-
-```mermaid
-flowchart LR
-    subgraph S1["Step 1: Export (x86 / Thor)"]
-        direction LR
-        A["Hugging Face<br/>model"] --> B[Quantize] --> C["ONNX<br/>export"]
-    end
-    subgraph S2["Step 2: Build runtime (each Jetson)"]
-        D["Build and compile<br/>C++ engine"]
-    end
-    C -->|"Transfer ONNX<br/>to each device"| D
-    D --> S3["Step 3: Thor<br/>CR2 8B · NVFP4"]
-    D --> S4["Step 4: Orin Nano<br/>Qwen3 4B · INT4"]
-    style S3 fill:#0d9488,color:#fff,stroke:#0d9488
-    style S4 fill:#d97706,color:#fff,stroke:#d97706
-```
-
-</div>
-
-1. **Step 1: Export models** (Python, x86 or Thor). Quantize and convert HuggingFace models to portable ONNX files. Transfer them to your target Jetson(s).
-2. **Step 2: Build the C++ runtime** (each Jetson). Clone the repo, compile the C++ engine builder and inference binary. TensorRT engines are hardware-specific and **must be built on the device that will run them**.
-3. **Step 3: Cosmos Reason2 8B on Thor** (NVFP4). Build engines and run VLM inference on Jetson Thor.
-4. **Step 4: Qwen3-4B-Instruct on Orin Nano** (INT4 AWQ). Build engines and run LLM inference on Jetson Orin Nano 8 GB.
-
-## Prerequisites
-
-### x86 Host / Jetson Thor (for Step 1: Model Export)
-
-<div style="overflow-x: auto; margin: 0.75rem 0 1.75rem;">
-<table style="width: 100%; border-collapse: collapse; font-size: 0.95rem; border: 1px solid #e2e8f0; border-radius: 0.5rem; overflow: hidden;">
-<thead>
-<tr style="background: #e2e8f0; color: #1e293b;">
-<th style="padding: 12px 16px; text-align: left; font-weight: 600; width: 28%;">Requirement</th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Details</th>
-</tr>
-</thead>
-<tbody>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">OS</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Ubuntu 22.04 or 24.04</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">GPU</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">NVIDIA GPU with Compute Capability 8.0+ (Ampere or newer)</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">GPU VRAM</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">24 GB+ recommended (48 GB+ for FP8 export of 8B models)</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">CUDA</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">12.x or 13.x</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">Python</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">3.10+</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; font-weight: 600; color: #334155;">Docker</td><td style="padding: 12px 16px;">Optional but recommended</td></tr>
-</tbody>
-</table>
-</div>
-
-### Jetson Target Device (for Step 2: Build and Inference)
-
-<div style="overflow-x: auto; margin: 0.75rem 0 1.25rem;">
-<table style="width: 100%; border-collapse: collapse; font-size: 0.95rem; border: 1px solid #e2e8f0; border-radius: 0.5rem; overflow: hidden;">
-<thead>
-<tr style="background: #e2e8f0; color: #1e293b;">
-<th style="padding: 12px 16px; text-align: left; font-weight: 600; width: 26%;">Requirement</th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Jetson Orin (AGX Orin / Orin NX / Orin Nano)</th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Thor</th>
-</tr>
-</thead>
-<tbody>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">JetPack</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">7.2 / Jetson Linux R39.2</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">7.1 / 7.2</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">CUDA</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">13.2 (included)</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">13.x (included)</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #334155;">TensorRT</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">10.x+ (included)</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">10.x+ (included)</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; font-weight: 600; color: #334155;">Storage</td><td style="padding: 12px 16px;">20–50 GB free (ONNX + engines)</td><td style="padding: 12px 16px;">20–50 GB free</td></tr>
-</tbody>
-</table>
-</div>
-
-## Quantization and Platform Compatibility
-
-<div style="overflow-x: auto; margin: 1.5rem 0;">
-<table style="width: 100%; border-collapse: collapse; font-size: 0.95rem;">
-<thead>
-<tr style="background: #e2e8f0; color: #1e293b;">
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Precision</th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Memory savings<br/><span style="font-weight: 500; font-size: 0.85em;">(vs FP16)</span></th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Jetson Orin<br/><span style="font-weight: 500; font-size: 0.85em;">CC 8.7 (<code>sm_87</code>)</span></th>
-<th style="padding: 12px 16px; text-align: left; font-weight: 600;">Jetson Thor<br/><span style="font-weight: 500; font-size: 0.85em;"><code>sm_110</code></span></th>
-</tr>
-</thead>
-<tbody>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 500;">FP16</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Baseline</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Supported</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Supported</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 500;">FP8</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">2x reduction</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Not available</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Supported</td></tr>
-<tr style="background: #f8fafc;"><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0; font-weight: 500;">INT4 AWQ</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">4x reduction</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Supported</td><td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">Supported</td></tr>
-<tr style="background: #ffffff;"><td style="padding: 12px 16px; font-weight: 500;">NVFP4</td><td style="padding: 12px 16px;">4x reduction</td><td style="padding: 12px 16px;">Not available</td><td style="padding: 12px 16px;">Supported</td></tr>
-</tbody>
-</table>
-</div>
-
-## Step 1: Export Models (x86 Host or Jetson Thor)
-
-This step converts HuggingFace models to quantized ONNX files. It requires significant GPU memory and Python, so it runs on either an **x86 workstation** or **Jetson Thor**, not on Orin devices.
-
-- **x86 workstation**: use this if you have a Linux PC or cloud GPU. After export, transfer the ONNX files to your Jetson.
-- **Jetson Thor**: run the export directly on Thor using the [NVIDIA PyTorch container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch). No separate PC needed.
-
-### 1.1 Set Up the Environment
-
-<Tabs labels={["Jetson Thor (Docker)", "x86 Host (Docker)", "x86 Host (venv)"]}>
-<div class="nv-tab-panel active">
-
-On Thor, use the [NVIDIA PyTorch container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) which ships with **PyTorch, CUDA, TensorRT, and ModelOpt** pre-installed for Jetson's aarch64/SBSA architecture.
+Download the workflow helper and create persistent cache directories:
 
 ```bash
-docker pull nvcr.io/nvidia/pytorch:26.05-py3
-
-docker run -it --runtime nvidia \
-    --name edgellm-export \
-    -v $(pwd):/workspace \
-    -w /workspace \
-    nvcr.io/nvidia/pytorch:26.05-py3 \
-    bash
+mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_model.sh \
+  -o "$HOME/run-edgellm-model"
+chmod +x "$HOME/run-edgellm-model"
 ```
 
-Inside the container, clone the repository and install. The `--system-site-packages` flag lets the venv inherit the container's NVIDIA-built PyTorch. We install Edge-LLM with `--no-deps` to prevent pip from replacing torch, then install the remaining dependencies separately while filtering out the torch lines.
+Free storage must cover the container, checkpoint, and device-specific engines
+at the same time. The ONNX workflow needs an additional copy of its exported
+graphs. Allow at least 35 GB for the small quick-start model; larger checkpoints
+require substantially more. On an 8 GB Orin Nano, use NVMe
+storage for the Docker data root and the two mounted cache directories. For a
+4B first build, also use NVMe-backed swap and stop the graphical desktop.
+
+Use the image that matches the Jetson GPU. The following command downloads a
+small public model, builds checkpoint-backed engines without ONNX, runs C++
+inference, and records prefill and decode benchmarks.
+
+### Jetson Orin
 
 ```bash
-git clone https://github.com/NVIDIA/TensorRT-Edge-LLM.git
-cd TensorRT-Edge-LLM
-git submodule update --init --recursive
-
-python3 -m venv --system-site-packages venv
-source venv/bin/activate
-
-pip3 install --no-deps .
-sed '/^torch/d' requirements.txt > /tmp/reqs.txt
-pip3 install -r /tmp/reqs.txt
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+  run-edgellm-model Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ
 ```
 
-If you are tempted to run a normal `pip install` instead, see [Troubleshooting](#troubleshooting) (first item: why plain pip breaks on Jetson).
-
-Set the workspace directory to `/workspace/` so exported files land directly on the host via the volume mount:
+### Jetson Thor
 
 ```bash
-export WORKSPACE_DIR=/workspace/tensorrt-edgellm-workspace
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+  run-edgellm-model AxionML/Qwen3.5-0.8B-NVFP4
 ```
 
-<div class="admonition warning">
-<p class="admonition-title">Use /workspace, not $HOME</p>
-<p>Inside the container <code>$HOME</code> is <code>/root</code>, which is <strong>not</strong> on the mounted volume. Always use <code>/workspace/...</code> so your ONNX files appear on the host automatically. When you <code>exit</code> the container, the workspace will be at <code>~/tensorrt-edgellm-workspace</code> (or wherever you ran <code>docker run</code> from).</p>
-</div>
+The helper caches matching engine artifacts. Repeating the command reuses
+them; `--builder onnx` additionally caches ONNX. Runs are stored under
+`$HOME/tensorrt-edgellm-workspace` with the
+generated input, output, profile, benchmark CSVs, `benchmark_summary.json`,
+manifest, log, and exact export/build/runtime commands. The command also prints
+the prefill and decode latency and tokens per second directly when it finishes.
+The `tensorrt-edgellm-0100-build` Docker volume also preserves C++ executables
+compiled by the first run, so later containers do not rebuild the same tools.
+When ONNX is selected, Hugging Face snapshots are exposed through a cache-local view
+of regular files; hard links avoid a second copy of the checkpoint when the
+cache and workspace use the same filesystem.
 
-</div>
+### Experimental Weightless Builder
 
-<div class="nv-tab-panel">
-
-Pull and launch the [NVIDIA PyTorch container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch):
+The default `--builder weightless` invokes `tensorrt-edgellm-build` once to
+discover and compile every registered component from the checkpoint:
 
 ```bash
-docker pull nvcr.io/nvidia/pytorch:26.05-py3
-
-docker run --gpus all -it \
-    --name edgellm-export \
-    -v $(pwd):/workspace \
-    -w /workspace \
-    nvcr.io/nvidia/pytorch:26.05-py3 \
-    bash
+run-edgellm-model Qwen/Qwen2.5-0.5B-Instruct
 ```
 
-Inside the container, clone the repository and install:
+The weightless frontend is experimental in 0.10.0. `--builder direct` remains
+an alias. It is intended for offline C++
+inference and benchmarking; `--stage serve` continues to use the supported ONNX
+workflow. Weightless engines keep checkpoint-backed weights outside the plan, so
+the original checkpoint directory must remain mounted when they run. The helper
+passes that directory to `llm_inference` and `llm_bench` automatically.
+
+With no externalization override, the builder requests checkpoint-backed INT4
+FFN, INT4 MoE, NVFP4 MoE, LM-head, FP16, and embedding weights. FP8 and MXFP8
+weights remain folded into the TensorRT plan by design, so “weightless” does
+not mean every precision produces a zero-weight plan. Passing
+`--externalize-weight` selects an explicit narrower policy.
+
+## 0.10.0 Support Audit
+
+The following matrix separates the release-supported ONNX workflow, code
+present in the experimental weightless registry, and completed Jetson runtime
+evidence. “Registered” means the frontend has model-owned graph and artifact
+definitions; it does not mean every checkpoint, precision, and feature
+combination has weightless-builder L0 coverage.
+
+| Model family or contract | Modality and runtime | Weightless components | 0.10.0 HTTP server | Runtime evidence in this update |
+|---|---|---|---|---|
+| Llama 3.x | Text generation | LLM | Chat completions | Source-audited; not hardware-swept here |
+| Qwen2 / Qwen2.5 | Text generation | LLM | Chat completions | Qwen2.5 0.5B passed offline and through the server on Orin NX |
+| Qwen3 dense and MoE | Text generation | LLM | Chat completions | Source-audited; not hardware-swept here |
+| Qwen2.5-VL and Qwen3-VL, including Cosmos Reason2 | Image/video and text to text | LLM and visual | Multimodal chat completions | Source-audited; not hardware-swept here |
+| Qwen3.5 / Qwen3.6 / Qwen3.8 dense and MoE | Image and text to text | LLM and visual | Multimodal chat completions | Qwen3.5 0.8B, 2B, and 9B passed offline; Qwen3.8 27B NVFP4 passed text, image, video, and native-MTP serving on Thor |
+| InternVL3 / InternVL3.5 | Image and text to text | LLM and visual | Multimodal chat completions | Source-audited; not hardware-swept here |
+| Phi-4 Multimodal | Image and text to text after its required vision-LoRA merge | LLM and visual | Multimodal chat completions | Source-audited; not hardware-swept here |
+| Nemotron-3 / 3.5 text | Text generation | LLM | Chat completions | 30B-A3B ONNX passed on Thor; weightless engine generation did not |
+| Nemotron Nano Omni | Image/video/audio and text to text | LLM, visual, and audio | Multimodal chat completions | Source-audited; not hardware-swept here |
+| Gemma4 | Image, checkpoint-dependent audio, and text to text | LLM, visual, and audio | Multimodal chat completions with an FP16 KV cache | Public E2B W4A16 GPTQ text/image/audio serving passed on Thor |
+| DiffusionGemma | Block-diffusion text/image/video understanding | Diffusion LLM and visual | No; use its C++ block-diffusion runtime | Source-audited; not hardware-swept here |
+| Qwen3-ASR | Audio to text | LLM and audio | Chat audio and `/v1/audio/transcriptions` | Both endpoints transcribed the bundled LibriSpeech clip correctly on Thor |
+| Nemotron-3.5-ASR | Streaming audio to transcript | Not registered; use `--builder onnx` | No; use its FastConformer/RNN-T runtime | ONNX FastConformer and RNN-T passed on Orin NX |
+| Qwen3-TTS | Text/reference voice to audio | Talker, CodePredictor, Code2Wav, and clone encoders | `/v1/audio/speech` for CustomVoice; Base and VoiceDesign remain offline | CustomVoice passed offline on Orin NX and through the speech server on Thor |
+| Qwen3-Omni | Image/audio/text to text and optional speech | LLM, visual, audio, Talker, CodePredictor, and Code2Wav | Multimodal chat and audio output | Source-audited; not hardware-swept here |
+| Alpamayo | Video/trajectory/text to text and trajectory | LLM, visual, and action | No; use its action runtime | Source-audited; not hardware-swept here |
+| Cosmos3-Edge reasoner | Image/video and text to text | LLM and visual | Multimodal chat completions | Source-audited; not hardware-swept here |
+| Cosmos3-Edge policy | Image/video and instruction to action chunk | Understanding prefill, generation, and VAE encoder | No; use its policy runtime | Passed on Thor |
+
+MTP, EAGLE3, and DFlash are optional text-generation extensions, not separate
+modalities. They are disabled unless requested and do not change the base
+model's visual or audio contract:
+
+| Extension | Checkpoint contract | Helper option | HTTP server | Validation in this update |
+|---|---|---|---|---|
+| MTP | Draft layer embedded in Qwen3.5/Qwen3.8, or a matched Gemma4 assistant | `--mtp` and optional `--mtp-draft` | Prebuilt speculative bundle | Public Qwen3.5 4B and Qwen3.8 27B native MTP passed through the server on Thor |
+| EAGLE3 | Base model plus matching EAGLE3 draft checkpoint | `--eagle3 DRAFT` | Prebuilt speculative bundle | Public Qwen3 1.7B base/draft pair passed through the server on Orin NX |
+| DFlash | Base model plus matching DFlash draft checkpoint | `--dflash DRAFT` | Prebuilt speculative bundle | Public Qwen3.5 4B base/draft pair passed through the server on Thor |
+
+Speculative serving is text-only in 0.10.0. DSpark remains available to the
+offline helper with `--dspark`, but is not advertised as an HTTP-server
+contract by this release.
+
+The fixed release list contains 186 unique Hugging Face checkpoint IDs. An
+anonymous audit on August 13, 2026 returned `config.json` for 176; the four
+original Meta Llama IDs and six Cosmos Reason2 IDs returned access denied.
+Of the public configs, 158 map to a registered model type and 16 are official
+EAGLE3, DFlash, or DSpark draft IDs. Nemotron-3.5-ASR is intentionally
+ONNX-only. The public `google/gemma-4-12B-it-assistant` uses the unregistered
+`gemma4_unified_assistant` draft type, so its MTP pair must also use ONNX in
+0.10.0. All 49 deployment checkpoints named in this tutorial exposed both
+metadata and an actual weight artifact without a Hugging Face token during the
+same audit.
+Forty-eight of those 49 deployment checkpoints map to a weightless registry
+entry; the sole exception is the explicitly ONNX-only Nemotron-3.5-ASR row.
+A second `--stage serve` command audit reached the model-appropriate HTTP
+launcher for 42 checkpoints. It correctly kept DiffusionGemma, Cosmos3 policy,
+and Nemotron-3.5-ASR on their model-specific offline runtimes. It also rejected
+four Gemma4 NVFP4 checkpoints before export because their FP8 KV caches cannot
+serve shared-KV attention in Edge-LLM 0.10.0. This is command and contract
+coverage; the hardware table below separately identifies real engine and
+inference runs.
+
+Qwen3.8 was released after that fixed August 13 audit. Its public ModelOpt
+NVFP4 checkpoint was audited separately on August 14 and routes through the
+existing Qwen3.5 model implementation without a compatibility patch.
+
+The registry also contains Mistral, Qwen2-VL, and Qwen3-Omni-Next model types,
+but the 0.10.0 release does not publish a validated checkpoint recommendation
+for those families. They are frontend implementations, not deployment claims
+on this page. Quantization/calibration, all tensor-parallel ranks in one
+builder invocation, checkpoint-backed serving, GGUF, and unrecognized
+`compressed-tensors` formats are not supported by the weightless helper.
+
+## New 0.10.0 Model Contracts
+
+The helper selects the runtime from checkpoint metadata. Commands use the
+weightless frontend unless `--builder onnx` is shown explicitly:
 
 ```bash
-git clone https://github.com/NVIDIA/TensorRT-Edge-LLM.git
-cd TensorRT-Edge-LLM
-git submodule update --init --recursive
+# Nemotron 3.5 Lightning text generation
+run-edgellm-model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+  --builder onnx
 
-python3 -m venv venv
-source venv/bin/activate
-pip3 install .
+# DiffusionGemma block-diffusion text/image/video understanding
+run-edgellm-model nvidia/diffusiongemma-26B-A4B-it-NVFP4 \
+  --builder onnx --image /data/input.jpg --prompt "Describe this image."
+
+# Cosmos3-Edge multimodal reasoner
+run-edgellm-model nvidia/Cosmos3-Edge \
+  --builder onnx --image /data/input.jpg --prompt "What should the robot do next?"
+
+# Qwen3.8 multimodal serving on Thor
+run-edgellm-model Inferact/Qwen3.8-27B-NVFP4 \
+  --builder onnx --stage serve
+
+# Cosmos3 policy: image + instruction -> action chunk
+run-edgellm-model nvidia/Cosmos3-Edge-Policy-DROID \
+  --image /data/observation.jpg --prompt "Pick up the banana and place it in the bowl."
+
+# Standalone RNN-T speech recognition: audio -> transcript
+run-edgellm-model nvidia/nemotron-3.5-asr-streaming-0.6b \
+  --builder onnx --audio /data/input.wav
+
+# Text to speech: text + speaker -> WAV audio
+run-edgellm-model Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
+  --prompt "TensorRT Edge-LLM is running on NVIDIA Jetson." --speaker ryan
 ```
 
-</div>
+Every checkpoint named on this page is public on Hugging Face and can be
+resolved without an access token.
 
-<div class="nv-tab-panel">
+Cosmos3 policy and Nemotron-3.5-ASR do not use the LLM JSON contract. The
+helper builds their model-specific binaries on first use, writes the policy
+action JSON or ASR transcript, and records their native end-to-end benchmark.
+Qwen3-TTS Base, CustomVoice, and VoiceDesign checkpoints similarly select the
+Qwen3-TTS executable and emit audio rather than text tokens.
 
-If you prefer not to use Docker, set up a virtual environment directly on your x86 host:
+### 0.10.0 Hardware Validation
+
+| Device | Container | Checkpoint and path | Result |
+|---|---|---|---|
+| Orin Nano 8 GB | `0.10.0-orin` | `QuantTrio/Qwen3.5-2B-AWQ`, experimental weightless builder; externalized INT4 LLM and vision engines | Image description coherent; prefill 904.5 tok/s at ISL 128; decode 20.6 tok/s at past-KV 128 and OSL 16; vision encoder 243.02 ms; 4.15 GB peak unified memory |
+| Orin NX 16 GB | `0.10.0-orin` | `Qwen/Qwen2.5-0.5B-Instruct`, experimental weightless builder | C++ answer coherent; prefill 3,607.6 tok/s at ISL 128; decode 59.2 tok/s at past-KV 128 and OSL 32 |
+| Orin NX 16 GB | `0.10.0-orin` | `Qwen/Qwen2.5-0.5B-Instruct`, ONNX export and OpenAI-compatible server | `/v1/models` returned the checkpoint; two-turn chat preserved context and correctly identified Paris and the Seine |
+| Orin NX 16 GB | `0.10.0-orin` | `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ`, experimental weightless builder; LLM and vision engines | Text answer coherent; image request completed; prefill 1,651.5 tok/s at ISL 128; decode 67.0 tok/s at past-KV 128 and OSL 32; vision encoder 58.64 ms |
+| Orin NX 16 GB | `0.10.0-orin` | `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ`, ONNX LLM and visual engines; OpenAI-compatible server | A real JPEG request returned HTTP 200 and correctly identified a woman and dog interacting on a beach |
+| Orin NX 16 GB | `0.10.0-orin` | `nvidia/nemotron-3.5-asr-streaming-0.6b`, ONNX export; FastConformer and RNN-T engines | Transcript matched the bundled golden text; 161.9 ms end to end for 3.505 s of audio; RTF 0.046 (21.6x real time) |
+| Orin NX 16 GB | `0.10.0-orin` | `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`, ONNX export; Talker, CodePredictor, and Code2Wav engines | Generated valid 5.76 s, 24 kHz mono WAV; ASR round trip preserved “is running on NVIDIA Jetson” with a product-name contraction; Talker 4,516.3 ms; Code2Wav 157.5 ms; 5.00 GB peak unified memory |
+| Orin NX 16 GB | `0.10.0-orin` | `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`, weightless Talker, CodePredictor, and Code2Wav engines; default helper path | Generated valid 4.88 s, 24 kHz mono WAV; independent Whisper round trip returned “Hello! NVIDIA Jetson is ready.”; Talker 4,952.1 ms; Code2Wav 181.7 ms; 4.38 GB peak unified memory |
+| Orin NX 16 GB | `0.10.0-orin` | `Qwen/Qwen3-1.7B` with `AngelSlim/Qwen3-1.7B_eagle3`, ONNX base/draft engines; speculative server | Health reported speculative decoding enabled and chat correctly returned `17 x 6 = 102` |
+| Jetson AGX Orin 64 GB | `0.10.0-orin` | `Vishva007/Qwen3.5-9B-W4A16-AutoRound-GPTQ`, experimental weightless builder; externalized INT4 LLM and FP16 visual weights | Image description coherent; prefill 1,078.6 tok/s at ISL 128; decode 27.6 tok/s at past-KV 128 and OSL 16; vision encoder 90.16 ms; 9.62 GB peak unified memory |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Qwen/Qwen3-ASR-0.6B`, ONNX LLM and audio engines; OpenAI-compatible server | Chat audio and `/v1/audio/transcriptions` both returned the correct LibriSpeech sentence, “Concord returned to its place amidst the tents.” |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`, ONNX Talker, CodePredictor, and Code2Wav engines; speech server | `/v1/audio/speech` returned a valid 24 kHz mono WAV; Qwen3-ASR recovered “NVIDIA Jetson is ready for Edge AI.” |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ`, ONNX LLM, visual, and audio engines; Gemma4 server adapter | Text preserved the `AURORA` context and named the Seine; image chat identified a woman and dog on a beach; audio chat exactly transcribed the bundled LibriSpeech sentence |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Inferact/Qwen3.8-27B-NVFP4`, ONNX LLM and visual engines; OpenAI-compatible server | Text preserved the `AURORA` context and named the Seine; image chat correctly described a woman interacting with a dog on a beach; MP4 video chat described the same person, animal, and interaction |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Inferact/Qwen3.8-27B-NVFP4`, native MTP; ONNX base/draft engines; speculative server | Health reported speculative decoding enabled and chat correctly returned `23 x 9 = 207` |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Qwen/Qwen3.5-4B`, native MTP; ONNX base/draft engines; speculative server | Health reported speculative decoding enabled and chat correctly returned `19 x 7 = 133` |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `Qwen/Qwen3.5-4B` with `z-lab/Qwen3.5-4B-DFlash`; ONNX base/draft engines; speculative server | Health reported speculative decoding enabled and chat correctly returned `23 x 9 = 207` |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, ONNX export | C++ answer coherent; prefill 1,771.0 tok/s at ISL 128; decode 80.8 tok/s at past-KV 128 and OSL 32 |
+| Jetson AGX Thor 128 GB | `0.10.0-thor` | `nvidia/Cosmos3-Edge-Policy-DROID`, experimental weightless builder; diffusion prefill, generation, and VAE encoder engines | A public Banana-in-Bowl frame and instruction produced a finite `1x16x10` action chunk; full-policy median 638.15 ms with one warmup and two measured iterations |
+
+This table reports completed engine builds and runtime executions, not metadata
+dry runs. Engines are rebuilt per GPU architecture.
+
+The experimental weightless frontend completed the Qwen and Cosmos3 bundles shown
+above. The Nemotron 3.5 Lightning weightless build exited during TensorRT engine
+generation in this sweep, so its validated row intentionally uses the supported
+ONNX path.
+
+## Verify Before Downloading Weights
+
+Append `--dry-run` to any model command to download JSON metadata only, inspect
+the architecture and precision, and emit the exact export and build commands
+without compiling an engine:
+
+On Jetson Orin:
 
 ```bash
-git clone https://github.com/NVIDIA/TensorRT-Edge-LLM.git
-cd TensorRT-Edge-LLM
-git submodule update --init --recursive
-
-python3 -m venv venv
-source venv/bin/activate
-pip3 install .
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+  run-edgellm-model Qwen/Qwen3-4B-AWQ --builder onnx --stage serve --dry-run
 ```
 
-</div>
-</Tabs>
-
-### 1.2 Verify Installation
+On Jetson Thor:
 
 ```bash
-tensorrt-edgellm-export --help
-tensorrt-edgellm-quantize llm --help
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+  run-edgellm-model baseten/Qwen3-4B-NVFP4-PTQ --builder onnx --stage serve --dry-run
 ```
 
-Both commands should print their usage information without errors.
+This validates command construction and checkpoint compatibility. Remove
+`--dry-run` to download the weights and execute the pipeline. A full hardware
+verification requires a real engine build and inference on the target Jetson.
 
-### 1.3 Log in to HuggingFace
+## Offline Inference and Serving
 
-Cosmos-Reason2-8B is a **gated model**: you must accept the license and authenticate before downloading.
+The default `--stage all` performs export, engine build, smoke inference, and
+benchmarks. Use `--stage serve` to build missing artifacts and launch the
+OpenAI-compatible server:
 
-1. Visit [nvidia/Cosmos-Reason2-8B](https://huggingface.co/nvidia/Cosmos-Reason2-8B) on HuggingFace and click **"Agree and access repository"**.
-2. Generate a token at [HuggingFace Settings - Tokens](https://huggingface.co/settings/tokens) (read access is sufficient).
-3. Log in from the terminal:
+On Jetson Orin:
 
 ```bash
-huggingface-cli login
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  -v "$HOME/media:/data/media:ro" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-orin \
+  run-edgellm-model Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ \
+    --builder onnx --stage serve \
+    --allowed-local-media-path /data/media
 ```
 
-Paste your token when prompted. This persists across sessions inside the container.
-
-### 1.4 Export Cosmos-Reason2-8B (VLM)
-
-Cosmos Reason2 is a vision-language model. TensorRT Edge-LLM exports the language model and visual encoder components from the quantized checkpoint with one command.
+On Jetson Thor:
 
 ```bash
-# Thor Docker users: WORKSPACE_DIR was already set to /workspace/tensorrt-edgellm-workspace in Step 1.1
-# x86 / venv users: set it now
-export WORKSPACE_DIR=${WORKSPACE_DIR:-$HOME/tensorrt-edgellm-workspace}
-export MODEL_NAME=Cosmos-Reason2-8B
-mkdir -p $WORKSPACE_DIR && cd $WORKSPACE_DIR
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v "$HOME/run-edgellm-model:/usr/local/bin/run-edgellm-model:ro" \
+  -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" \
+  -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" \
+  -v "$HOME/.cache/huggingface:/data/models/huggingface" \
+  ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor \
+  run-edgellm-model baseten/Qwen3-4B-NVFP4-PTQ --builder onnx --stage serve
 ```
 
-#### Quantize the Language Model
-
-<Tabs labels={["NVFP4 (Thor, recommended)", "INT4 AWQ (Orin / Thor)", "FP8 (Thor / x86 Dev GPU)"]}>
-<div class="nv-tab-panel active">
-
-NVFP4 is the recommended precision for Thor (SM110+), offering 4x memory reduction with native hardware support.
+If you substitute a gated checkpoint, accept its license on Hugging Face and
+pass your token into the container:
 
 ```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir nvidia/Cosmos-Reason2-8B \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization nvfp4
+-e HF_TOKEN="$HF_TOKEN"
 ```
 
-</div>
-
-<div class="nv-tab-panel">
-
-INT4 AWQ reduces the 8B language-model weights to roughly 4 GB. Use it when deploying on Orin devices (SM87) or Thor.
+Serving uses the ONNX frontend in 0.10.0. The experimental weightless plans are
+for offline inference and benchmarking. Use these request forms after the
+server is healthy:
 
 ```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir nvidia/Cosmos-Reason2-8B \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization int4_awq
+# Text
+curl -sS http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"local","messages":[{"role":"user","content":"Name the river through Paris."}],"max_tokens":64}'
+
+# Image from the allowlisted directory mounted above
+curl -sS http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"local","messages":[{"role":"user","content":[{"type":"image","image":"/data/media/input.jpg"},{"type":"text","text":"Describe the image in one sentence."}]}],"max_tokens":128}'
+
+# Qwen3-ASR upload
+curl -sS http://127.0.0.1:8000/v1/audio/transcriptions \
+  -F model=local -F response_format=json -F file=@sample.wav
 ```
 
-</div>
-
-<div class="nv-tab-panel">
-
-FP8 requires SM89+ at build time. Use this if your target is Thor or an Ada Lovelace+ dev GPU.
+Qwen3-TTS CustomVoice has a speech-only server contract:
 
 ```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir nvidia/Cosmos-Reason2-8B \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization fp8
+run-edgellm-model Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
+  --builder onnx --stage serve
+
+curl -sS http://127.0.0.1:8000/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"local","input":"TensorRT Edge-LLM is ready.","voice":"ryan","response_format":"wav"}' \
+  --output response.wav
 ```
 
-</div>
-</Tabs>
+The server accepts text, image, audio, and video only when the selected model
+provides those engines. Qwen3-TTS Base and VoiceDesign, DiffusionGemma,
+Cosmos3 policy, Alpamayo action generation, and Nemotron-3.5 RNN-T ASR keep
+their model-specific offline runtimes.
 
-#### Export Checkpoint to ONNX
+### Optional Speculative Extensions
+
+MTP, EAGLE3, and DFlash are explicit extensions to a compatible text model.
+Each command exports and builds the base and draft plans together, then starts
+the same chat API with speculative decoding enabled:
 
 ```bash
-tensorrt-edgellm-export \
-    $MODEL_NAME/quantized \
-    $MODEL_NAME/onnx
+# Native MTP
+run-edgellm-model Qwen/Qwen3.5-4B \
+  --builder onnx --stage serve --mtp
+
+# EAGLE3 pair
+run-edgellm-model Qwen/Qwen3-1.7B \
+  --builder onnx --stage serve \
+  --eagle3 AngelSlim/Qwen3-1.7B_eagle3
+
+# DFlash pair
+run-edgellm-model Qwen/Qwen3.5-4B \
+  --builder onnx --stage serve \
+  --dflash z-lab/Qwen3.5-4B-DFlash
 ```
 
-### 1.5 Export Qwen3-4B-Instruct (LLM)
+These checkpoint IDs are public. Speculative server requests are text-only in
+0.10.0; build and serve the base model without a speculative option for image,
+audio, or video input.
 
-Qwen3-4B-Instruct is a text-only LLM. It supports INT4 AWQ, which brings the 4B model down to ~2 GB of weights, a comfortable fit for Orin Nano's 8 GB unified memory. No HuggingFace login is needed (Apache 2.0 license).
+## Custom Inputs
+
+Use prompt and media options to generate an Edge-LLM request JSON:
 
 ```bash
-# Thor Docker users: WORKSPACE_DIR was already set to /workspace/tensorrt-edgellm-workspace in Step 1.1
-# x86 / venv users: set it now
-export WORKSPACE_DIR=${WORKSPACE_DIR:-$HOME/tensorrt-edgellm-workspace}
-export MODEL_NAME=Qwen3-4B-Instruct
-mkdir -p $WORKSPACE_DIR && cd $WORKSPACE_DIR
+# Text
+run-edgellm-model MODEL --prompt "Summarize unified memory on Jetson."
+
+# Image and text
+run-edgellm-model MODEL \
+  --image /data/input.jpg \
+  --prompt "Describe this image."
+
+# Audio and text
+run-edgellm-model MODEL \
+  --audio /data/input.wav \
+  --prompt "Transcribe this speech in its original language. Output only the transcription."
+
+# Qwen3-TTS Base voice clone (omit --ref-text for timbre-only cloning)
+run-edgellm-model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
+  --ref-audio /data/reference.wav \
+  --ref-text "Exact transcript of the reference audio." \
+  --prompt "This sentence uses the cloned voice."
+
+# Qwen3-TTS VoiceDesign
+run-edgellm-model Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --tts-instruct "A calm, warm narrator speaking slowly." \
+  --prompt "TensorRT Edge-LLM is running on NVIDIA Jetson."
+
+# Video frames and text
+run-edgellm-model MODEL \
+  --video-frame /data/frame-0001.jpg \
+  --video-frame /data/frame-0002.jpg \
+  --video-fps 2 \
+  --prompt "Describe what changes between these frames."
 ```
 
-#### Quantize and Export
-
-<Tabs labels={["INT4 AWQ (Orin Nano, recommended)", "FP8 (Thor / x86 Dev GPU)", "NVFP4 (Thor Only)"]}>
-<div class="nv-tab-panel active">
-
-INT4 AWQ reduces the 4B model to ~2 GB of weights, leaving plenty of headroom for KV cache on Orin Nano.
+Mount media files into the container at the same paths used by the command.
+For Gemma 4, the helper places the transcription instruction before the audio
+item, matching the model provider's recommended modality order.
+Every frame in one video request must have the same width, height, and channel
+count. Keep the tokenized text and media in each request within the engine's
+`--max-input-len`; use separate requests for independent modalities or build a
+larger input profile. An existing Edge-LLM request can be passed through
+unchanged. Image, audio, and video options require the corresponding component
+shown in the validated checkpoint table below:
 
 ```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir Qwen/Qwen3-4B-Instruct-2507 \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization int4_awq
-
-tensorrt-edgellm-export \
-    $MODEL_NAME/quantized \
-    $MODEL_NAME/onnx
+run-edgellm-model MODEL --input-json /data/request.json
 ```
 
-</div>
+Useful profile controls include `--batch-size`, `--max-batch-size`,
+`--max-input-len`, `--max-kv-cache-capacity`, `--prefill-len`,
+`--past-kv-len`, and `--bench-output-len`. Benchmarks report E2E timing by
+default; `--bench-arg=--profile` adds a separate layer-profile pass. Run
+`run-edgellm-model --help` for component-specific exporter, builder, runtime,
+and benchmark overrides.
 
-<div class="nv-tab-panel">
+Nemotron Nano Omni supports text, image, audio, and video input. The helper
+builds every component in the checkpoint and uses the real multimodal runtime
+profile for end-to-end timing.
+
+## Published Checkpoint Policy
+
+Support depends on both architecture and checkpoint format. A model working in
+llama.cpp or vLLM does not imply that the same file works in Edge-LLM:
+
+- GGUF files remain llama.cpp inputs.
+- The `compressed-tensors` W4A16 checkpoints used by several vLLM cards are
+  not substituted for Edge-LLM checkpoints.
+- This deployment matrix uses published W4A16, AWQ, or GPTQ INT4 checkpoints
+  on Orin. It does not substitute an original FP16/BF16 repository.
+- Thor uses a published NVFP4 checkpoint when a compatible one is available.
+  The table names the exact FP8 or GPTQ fallback where no compatible NVFP4
+  checkpoint was validated.
+- The official `Qwen/Qwen3.8-27B-FP8` fine-grained FP8 metadata is not accepted
+  by Edge-LLM 0.10.0. The public ModelOpt NVFP4 checkpoint listed below passed
+  export, engine build, and runtime validation instead.
+- The weightless builder uses the original checkpoint for supported runtime
+  weight bindings. The ONNX workflow can externalize already-quantized INT4
+  FFN/MoE and NVFP4 MoE bundles and hard-link them into the engine directory.
+  Neither path quantizes weights.
+- For incomplete community Gemma 4 metadata, the helper can create a
+  non-mutating compatibility view. It does not rewrite or quantize checkpoint
+  tensors.
+
+The checkpoints below are publisher or community releases available from
+Hugging Face and selected for the memory and precision supported by each
+device. They were exercised in the earlier hardware sweep and remain within
+the 0.10.0 supported architecture and checkpoint formats. The release
+validation table below records the subset rebuilt with the 0.10.0 containers;
+the remaining rows are recommendations, not claims of a fresh 0.10.0 rebuild.
+
+### Jetson Orin Nano 8 GB
+
+| Jetson AI Lab model card | Edge-LLM checkpoint | Inputs exercised |
+|---|---|---|
+| [Qwen3.5 0.8B](/models/qwen3-5-0-8b) | `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 2B](/models/qwen3-5-2b) | `QuantTrio/Qwen3.5-2B-AWQ` | Text, image |
+| [Qwen3-VL 2B](/models/qwen3-vl-2b) | `Vishva007/Qwen3-VL-2B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 4B](/models/qwen3-5-4b) | `vastai-ais/Qwen3.5-4B-AutoRound-GPTQ-Int4` | Text, image |
+| [Qwen3 4B](/models/qwen3-4b) | `Qwen/Qwen3-4B-AWQ` | Text |
+| [Qwen3-VL 4B](/models/qwen3-vl-4b) | `Vishva007/Qwen3-VL-4B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+
+### Jetson Orin NX 16 GB
+
+| Jetson AI Lab model card | Edge-LLM checkpoint | Inputs exercised |
+|---|---|---|
+| [Qwen3.5 0.8B](/models/qwen3-5-0-8b) | `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 2B](/models/qwen3-5-2b) | `QuantTrio/Qwen3.5-2B-AWQ` | Text, image |
+| [Qwen3-VL 2B](/models/qwen3-vl-2b) | `Vishva007/Qwen3-VL-2B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 4B](/models/qwen3-5-4b) | `vastai-ais/Qwen3.5-4B-AutoRound-GPTQ-Int4` | Text, image |
+| [Qwen3 4B](/models/qwen3-4b) | `Qwen/Qwen3-4B-AWQ` | Text |
+| [Qwen3-VL 4B](/models/qwen3-vl-4b) | `Vishva007/Qwen3-VL-4B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3 8B](/models/qwen3-8b) | `kaitchup/Qwen3-8B-autoround-4bit-gptq` | Text |
+| [Llama 3.1 8B](/models/llama3-1-8b) | `RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16` | Text |
+| [Qwen3-VL 8B](/models/qwen3-vl-8b) | `Vishva007/Qwen3-VL-8B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Gemma 4 E2B](/models/gemma4-e2b) | `Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ` | Text, image, audio |
+
+The Qwen3 8B first-run ONNX export exceeded the NX default 2 GB swap. Configure
+at least 8 GB of additional swap on NVMe before building it; the cached engine
+does not repeat this export.
+
+### Jetson AGX Orin 64 GB
+
+| Jetson AI Lab model card | Edge-LLM checkpoint | Inputs exercised |
+|---|---|---|
+| [Qwen3.5 0.8B](/models/qwen3-5-0-8b) | `Vishva007/Qwen3.5-0.8B-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 4B](/models/qwen3-5-4b) | `vastai-ais/Qwen3.5-4B-AutoRound-GPTQ-Int4` | Text, image |
+| [Qwen3 4B](/models/qwen3-4b) | `Qwen/Qwen3-4B-AWQ` | Text |
+| [Qwen3-VL 4B](/models/qwen3-vl-4b) | `Vishva007/Qwen3-VL-4B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3 8B](/models/qwen3-8b) | `kaitchup/Qwen3-8B-autoround-4bit-gptq` | Text |
+| [Llama 3.1 8B](/models/llama3-1-8b) | `RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16` | Text |
+| [Qwen3-VL 8B](/models/qwen3-vl-8b) | `Vishva007/Qwen3-VL-8B-Instruct-W4A16-AutoRound-GPTQ` | Text, image |
+| [Gemma 4 E2B](/models/gemma4-e2b) | `Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ` | Text, image, audio |
+| [Gemma 4 E4B](/models/gemma4-e4b) | `Vishva007/gemma-4-E4B-it-W4A16-AutoRound-GPTQ` | Text, image, audio |
+| [Qwen3.5 9B](/models/qwen3-5-9b) | `Vishva007/Qwen3.5-9B-W4A16-AutoRound-GPTQ` | Text, image |
+| [Qwen3.5 27B](/models/qwen3-5-27b) | `QuantTrio/Qwen3.5-27B-AWQ` | Text, image |
+| [Qwen3.5 35B-A3B](/models/qwen3-5-35b-a3b) | `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` | Text, image |
+| [Qwen3 30B-A3B](/models/qwen3-30b-a3b) | `Qwen/Qwen3-30B-A3B-GPTQ-Int4` | Text |
+| [Qwen3.6 27B](/models/qwen3-6-27b) | `QuantTrio/Qwen3.6-27B-AWQ` | Text, image |
+| [Qwen3.6 35B-A3B](/models/qwen3-6-35b-a3b) | `palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4` | Text, image |
+
+### Jetson AGX Thor T5000 128 GB
+
+| Jetson AI Lab model card | Edge-LLM checkpoint | Inputs exercised |
+|---|---|---|
+| [Qwen3.5 0.8B](/models/qwen3-5-0-8b) | `AxionML/Qwen3.5-0.8B-NVFP4` | Text, image |
+| [Qwen3.5 2B](/models/qwen3-5-2b) | `AxionML/Qwen3.5-2B-NVFP4` | Text, image |
+| [Qwen3-VL 2B](/models/qwen3-vl-2b) | `cybermotaz/qwen3-vl-2b-thinking-nvfp4-w4a16` | Text, image |
+| [Cosmos Reason2 2B](/models/cosmos-reason2-2b) | `cagataydev/cosmos-reason2-2b-fp8-hf` | Text, image, video frames |
+| [Gemma 4 E2B](/models/gemma4-e2b) | `Vishva007/gemma-4-E2B-it-W4A16-AutoRound-GPTQ` | Text, image, audio |
+| [Gemma 4 E4B](/models/gemma4-e4b) | `Vishva007/gemma-4-E4B-it-W4A16-AutoRound-GPTQ` | Text, image, audio |
+| [Qwen3 4B](/models/qwen3-4b) | `baseten/Qwen3-4B-NVFP4-PTQ` | Text |
+| [Nemotron3 Nano 4B](/models/nemotron3-nano-4b) | `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` | Text |
+| [Qwen3-VL 4B](/models/qwen3-vl-4b) | `cybermotaz/qwen3-vl-4b-thinking-nvfp4-w4a16` | Text, image |
+| [Llama 3.1 8B](/models/llama3-1-8b) | `nvidia/Llama-3.1-8B-Instruct-NVFP4` | Text |
+| [Qwen3 8B](/models/qwen3-8b) | `nvidia/Qwen3-8B-NVFP4` | Text |
+| [Qwen3-VL 8B](/models/qwen3-vl-8b) | `cybermotaz/qwen3-vl-8b-thinking-nvfp4-w4a16` | Text, image |
+| [Nemotron Nano 9B v2](/models/nemotron-nano-9b-v2) | `nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4` | Text |
+| [Qwen3.5 4B](/models/qwen3-5-4b) | `AxionML/Qwen3.5-4B-NVFP4` | Text, image |
+| [Qwen3.5 9B](/models/qwen3-5-9b) | `AxionML/Qwen3.5-9B-NVFP4` | Text, image |
+| [Gemma 4 12B](/models/gemma4-12b) | `google/gemma-4-12B-it` | Text, image, audio |
+| [Qwen3.5 27B](/models/qwen3-5-27b) | `txn545/Qwen3.5-27B-NVFP4` | Text, image |
+| [Qwen3.5 35B-A3B](/models/qwen3-5-35b-a3b) | `AxionML/Qwen3.5-35B-A3B-NVFP4` | Text, image |
+| [Nemotron 3.5 Lightning](/models/nemotron3-5-lightning) | `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4` | Text; optional MTP, DFlash, or DSpark |
+| [Qwen3 30B-A3B](/models/qwen3-30b-a3b) | `nvidia/Qwen3-30B-A3B-NVFP4` | Text |
+| [Qwen3.6 27B](/models/qwen3-6-27b) | `natfii/Qwen3.6-27B-VLM-NVFP4-MTP` | Text, image, MTP |
+| [Qwen3.6 35B-A3B](/models/qwen3-6-35b-a3b) | `ykarout/Qwen3.6-35B-A3B-NVFP4` | Text, image |
+| [Qwen3.8 27B](/models/qwen3-8-27b) | `Inferact/Qwen3.8-27B-NVFP4` | Text, image, video; optional native MTP for text |
+| [DiffusionGemma 26B-A4B](/models/diffusiongemma-26b-a4b) | `nvidia/diffusiongemma-26B-A4B-it-NVFP4` | Text, image, video frames |
+| [Nemotron3 Nano 30B-A3B](/models/nemotron-3-nano-30b-a3b) | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4` | Text |
+| [Nemotron 3 Nano Omni](/models/nemotron-3-nano-omni) | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4` | Text, image, audio |
+| [Cosmos3 Edge](/models/cosmos3-edge) | `nvidia/Cosmos3-Edge` or `nvidia/Cosmos3-Edge-Policy-DROID` | Reasoning: text/image/video to text; policy: image/instruction to action chunk |
+
+The Thor table uses GPTQ for Gemma4 E2B/E4B and omits the 26B/31B NVFP4
+checkpoints because those releases request an FP8 KV cache. Edge-LLM 0.10.0
+shared-KV attention cannot consume that donor-cache format; the helper rejects
+this combination before export.
+
+Models shown elsewhere in Jetson AI Lab only through llama.cpp, Ollama, or
+vLLM are intentionally excluded when Edge-LLM 0.10.0 does not list their
+architecture and format. This includes Gemma 3, GPT-OSS, MiniMax M2.7,
+Ministral 3, Cosmos3 Nano, Qwen3 32B, and Llama 3.1 70B.
+
+## Choose a Model by Memory
+
+Keep model weights near or below one third of unified memory so TensorRT
+engines, activation workspace, KV cache, multimodal encoders, and the OS retain
+headroom. Estimate stored weights from **total** parameters, including all MoE
+experts:
+
+- INT4/NVFP4: about `0.5 GB x parameters in B`
+- FP8: about `1 GB x parameters in B`
+- FP16/BF16: about `2 GB x parameters in B`
+
+- **Orin Nano, 8 GB:** target about 2.7 GB of weights. Published 2B and 4B
+  INT4 checkpoints run with externalized weights and the helper's automatic
+  low-memory profile. Use NVMe-backed swap and a headless session for a 4B
+  first build.
+- **Orin NX, 16 GB:** target about 5.3 GB of weights; up to 8B at INT4.
+- **AGX Orin, 64 GB:** target about 21.3 GB of weights; up to a 35B-A3B
+  model at INT4 when the exact checkpoint is listed above.
+- **AGX Thor T5000, 128 GB:** target about 42.7 GB of weights; most
+  explicitly supported 0.10.0 checkpoints fit, subject to runtime workspace.
+
+Every platform named in the validated tables above was exercised with the
+published checkpoint format shown there. Capacity estimates are not presented
+as support claims.
+
+### Hardware-validated starting points
+
+| Target | Start with |
+|---|---|
+| Orin Nano 8 GB | Qwen3.5 0.8B/2B/4B, Qwen3-VL 2B/4B, or Qwen3 4B INT4; the helper selects the low-memory profile automatically |
+| Orin NX 16 GB | Qwen3 8B AutoRound GPTQ, Qwen3-VL 8B W4A16 GPTQ, or Gemma 4 E2B W4A16 GPTQ |
+| AGX Orin 64 GB | Qwen3 4B AWQ, 8B AutoRound GPTQ, or 30B-A3B GPTQ; Qwen3.5 0.8B/4B/9B W4A16 GPTQ, 27B AWQ, or 35B-A3B GPTQ; Qwen3.6 27B AWQ or 35B-A3B GPTQ; Qwen3-VL 4B/8B W4A16 GPTQ; Gemma 4 E2B/E4B W4A16 GPTQ; or Llama 3.1 8B W4A16 |
+| AGX Thor T5000 128 GB | Use an exact checkpoint from the Thor table; NVFP4 is preferred, with the listed FP8 or GPTQ fallback where no compatible NVFP4 checkpoint passed |
+
+## Speculative Decoding
+
+Speculative decoding is never enabled implicitly. Use only a published draft
+checkpoint paired with its documented base model:
 
 ```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir Qwen/Qwen3-4B-Instruct-2507 \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization fp8
-
-tensorrt-edgellm-export \
-    $MODEL_NAME/quantized \
-    $MODEL_NAME/onnx
+run-edgellm-model BASE_MODEL --mtp
+run-edgellm-model BASE_MODEL --eagle3 DRAFT_MODEL
+run-edgellm-model BASE_MODEL --dflash DRAFT_MODEL
+run-edgellm-model BASE_MODEL --dspark DRAFT_MODEL
 ```
 
-</div>
-
-<div class="nv-tab-panel">
-
-```bash
-tensorrt-edgellm-quantize llm \
-    --model_dir Qwen/Qwen3-4B-Instruct-2507 \
-    --output_dir $MODEL_NAME/quantized \
-    --quantization nvfp4
-
-tensorrt-edgellm-export \
-    $MODEL_NAME/quantized \
-    $MODEL_NAME/onnx
-```
-
-</div>
-</Tabs>
-
-### 1.6 Transfer ONNX Files to Jetson
-
-ONNX from Step 1 sits on whatever machine ran the export (your x86 workstation or Jetson Thor). Copy each model’s ONNX folder only onto the Jetson that will build engines for that model: **Cosmos Reason2 8B** on Thor, **Qwen3-4B-Instruct** on Orin Nano.
-
-<div class="admonition tip">
-<p class="admonition-title">💡 Exported on Jetson Thor?</p>
-<p>Both models' ONNX files are already on your Thor host (they landed in <code>tensorrt-edgellm-workspace/</code> via the Docker volume mount). Skip the Thor <code>scp</code> below — you only need to copy <strong>Qwen3-4B-Instruct</strong> ONNX to the Orin Nano.</p>
-</div>
-
-**Exported on x86?** Use both `scp` blocks below. **Exported on Thor?** Use only the Orin Nano block for Qwen3.
-
-**To Jetson Thor** (Cosmos-Reason2-8B ONNX):
-
-```bash
-scp -r Cosmos-Reason2-8B/onnx <user>@<thor-ip>:~/tensorrt-edgellm-workspace/Cosmos-Reason2-8B/
-```
-
-**To Jetson Orin Nano** (Qwen3-4B-Instruct ONNX):
-
-```bash
-scp -r Qwen3-4B-Instruct/onnx <user>@<orin-nano-ip>:~/tensorrt-edgellm-workspace/Qwen3-4B-Instruct/
-```
-
-Create the target directories first if they do not exist:
-
-```bash
-ssh <user>@<thor-ip> "mkdir -p ~/tensorrt-edgellm-workspace/Cosmos-Reason2-8B"
-ssh <user>@<orin-nano-ip> "mkdir -p ~/tensorrt-edgellm-workspace/Qwen3-4B-Instruct"
-```
-
-If you followed this tutorial's Docker instructions (which set `WORKSPACE_DIR` under `/workspace/`), the ONNX files are already on the host and no extra copy step is needed.
-
-## Step 2: Build the C++ Runtime on Your Jetson
-
-Everything from here forward runs **on the target Jetson device** and is **pure C++**; no Python needed. Run steps 2.1–2.5 on **your** target device, then follow the section for your device:
-
-<div class="admonition warning">
-<p class="admonition-title">Why must this run on the target device?</p>
-<p>TensorRT compiles ONNX graphs into engine binaries that are <strong>optimized for the exact GPU they run on</strong>: kernel selection, memory layout, and fused operations are all hardware-specific. An engine built on Thor (SM110) will <strong>not</strong> load on Orin Nano (SM87), and vice versa. Unlike the ONNX files from Step 1 (which are portable), engines must be built on the same device that will execute them.</p>
-</div>
-
-<div class="admonition tip">
-<p class="admonition-title">💡 Thor users who exported on-device</p>
-<p>Exit the Docker container (<code>exit</code>). Because <code>WORKSPACE_DIR</code> was set to <code>/workspace/tensorrt-edgellm-workspace</code>, the ONNX files are already on the host in the directory where you ran <code>docker run</code>. Fix root-owned permissions, then proceed:</p>
-</div>
-
-```bash
-sudo chown -R $(whoami):$(whoami) tensorrt-edgellm-workspace
-```
-
-### 2.1 Install Build Dependencies
-
-<Tabs labels={["Jetson Thor (JetPack 7.1 / 7.2)", "Jetson Orin (JetPack 7.2 / R39.2)"]}>
-<div class="nv-tab-panel active">
-
-```bash
-sudo apt update
-sudo apt install -y cmake build-essential git \
-    cuda-toolkit-13-2 \
-    libnvinfer-headers-dev libnvinfer-dev libnvonnxparsers-dev
-export PATH=/usr/local/cuda/bin:$PATH
-```
-
-</div>
-
-<div class="nv-tab-panel">
-
-```bash
-sudo apt update
-sudo apt install -y cmake build-essential git \
-    cuda-toolkit-13-2 \
-    libnvinfer-headers-dev libnvinfer-dev libnvonnxparsers-dev
-export PATH=/usr/local/cuda/bin:$PATH
-```
-
-</div>
-</Tabs>
-
-Verify `nvcc` is available:
-
-```bash
-nvcc --version
-```
-
-For Jetson Orin, also confirm the device is running the JetPack 7.2 stack before building:
-
-```bash
-cat /etc/nv_tegra_release
-dpkg-query -W nvidia-l4t-core 'cuda-toolkit-13-2'
-```
-
-Expected versions are Jetson Linux `39.2.x` and `cuda-toolkit-13-2`.
-
-<details class="nv-details">
-<summary>Do not install Ubuntu <code>nvidia-cuda-toolkit</code></summary>
-<div class="nv-details-content">
-
-Use the <code>cuda-toolkit-*</code> package from NVIDIA’s repo (as in the commands above), <strong>not</strong> the Ubuntu <code>nvidia-cuda-toolkit</code> package, which conflicts with JetPack CUDA libraries.
-
-</div>
-</details>
-
-### 2.2 Clone the Repository
-
-```bash
-cd ~
-git clone https://github.com/NVIDIA/TensorRT-Edge-LLM.git
-cd TensorRT-Edge-LLM
-git submodule update --init --recursive
-```
-
-### 2.3 Configure and Build
-
-If you previously ran Docker with a volume mount into this repo, fix file ownership first:
-
-```bash
-sudo chown -R $(whoami):$(whoami) ~/TensorRT-Edge-LLM
-```
-
-<Tabs labels={["Jetson Thor", "Jetson Orin (AGX Orin / Orin NX / Orin Nano)"]}>
-<div class="nv-tab-panel active">
-
-```bash
-cd ~/TensorRT-Edge-LLM
-rm -rf build
-mkdir build && cd build
-
-cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DTRT_PACKAGE_DIR=/usr \
-    -DCMAKE_TOOLCHAIN_FILE=cmake/aarch64_linux_toolchain.cmake \
-    -DEMBEDDED_TARGET=jetson-thor \
-    -DCUDA_CTK_VERSION=13.0 \
-    -DENABLE_CUTE_DSL=ALL
-
-make -j$(nproc)
-```
-
-</div>
-
-<div class="nv-tab-panel">
-
-```bash
-cd ~/TensorRT-Edge-LLM
-rm -rf build
-mkdir build && cd build
-
-cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DTRT_PACKAGE_DIR=/usr \
-    -DCMAKE_TOOLCHAIN_FILE=cmake/aarch64_linux_toolchain.cmake \
-    -DEMBEDDED_TARGET=jetson-orin \
-    -DCUDA_CTK_VERSION=13.2 \
-    -DENABLE_CUTE_DSL=ALL
-
-make -j$(nproc)
-```
-
-</div>
-</Tabs>
-
-
-### 2.4 Verify the Build
-
-```bash
-cd ~/TensorRT-Edge-LLM
-./build/examples/llm/llm_build --help
-./build/examples/llm/llm_inference --help
-```
-
-### 2.5 Set Up Environment Variables
-
-The `EDGELLM_PLUGIN_PATH` variable tells the runtime where to find the Edge-LLM custom TensorRT plugins (AttentionPlugin, Int4GemmPlugin, etc.):
-
-```bash
-cd ~/TensorRT-Edge-LLM
-export EDGELLM_PLUGIN_PATH=$(pwd)/build/libNvInfer_edgellm_plugin.so
-export WORKSPACE_DIR=$HOME/tensorrt-edgellm-workspace
-```
-
----
-
-### Choose Your Deployment Path
-
-After completing Step 2, follow the section that matches your device. Steps 3 and 4 below are worked examples, but the same workflow applies to **any Jetson** (AGX Orin, Orin NX, etc.) with any [supported model](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/docs/source/user_guide/getting_started/supported-models.md), as long as the model fits in memory and you use a quantization format your GPU supports (see the [precision table](#quantization-and-platform-compatibility) above).
-
-<div class="mermaid-diagram">
-
-```mermaid
-flowchart TD
-    S2["Step 2 ✅: C++ runtime built"]
-    S2 --> T{"Which Jetson?"}
-    T -->|"Jetson Thor<br/>(SM110, 64 GB)"| S3["Step 3<br/>Cosmos Reason2 8B<br/>NVFP4 · VLM"]
-    T -->|"Orin Nano 8 GB<br/>(SM87, 8 GB)"| S4["Step 4<br/>Qwen3-4B-Instruct<br/>INT4 AWQ · LLM"]
-    T -.->|"AGX Orin / Orin NX<br/>(SM87, 32–64 GB)"| S5["Any supported model<br/>INT4 AWQ or FP16"]
-    style S3 fill:#0d9488,color:#fff,stroke:#0d9488
-    style S4 fill:#d97706,color:#fff,stroke:#d97706
-    style S5 fill:#6366f1,color:#fff,stroke:#6366f1
-    style T fill:#334155,color:#fff,stroke:#475569
-```
-
-</div>
-
-## Step 3: Cosmos Reason2 8B on Jetson Thor (NVFP4)
-
-<div style="border-left: 4px solid #0d9488; background: linear-gradient(135deg, #f0fdfa 0%, #ccfbf1 100%); padding: 16px 20px; border-radius: 0 8px 8px 0; margin-bottom: 1.5rem;">
-<p style="margin: 0; font-size: 1.05rem; font-weight: 600; color: #0d9488;">🟢 Jetson Thor: 8B VLM with NVFP4 quantization</p>
-<p style="margin: 0.5rem 0 0 0; color: #374151; font-size: 0.9rem;">Cosmos Reason2 8B is an 8B vision-language model (LLM + visual encoder). NVFP4 is a Thor-exclusive precision (SM110+) that reduces weights to ~4 GB. This section runs entirely on <strong>Jetson Thor</strong>. If you only have an Orin Nano, <a href="#step-4-qwen3-4b-instruct-on-jetson-orin-nano-8-gb-int4-awq">skip to Step 4</a>.</p>
-</div>
-
-### 3.1 Build the Language Model Engine
-
-```bash
-export MODEL_NAME=Cosmos-Reason2-8B
-
-./build/examples/llm/llm_build \
-    --onnxDir $WORKSPACE_DIR/$MODEL_NAME/onnx/llm \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine/llm \
-    --maxBatchSize 1 \
-    --maxInputLen 1024 \
-    --maxKVCacheCapacity 4096
-```
-
-### 3.2 Build the Visual Encoder Engine
-
-```bash
-./build/examples/multimodal/visual_build \
-    --onnxDir $WORKSPACE_DIR/$MODEL_NAME/onnx/visual \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine
-```
-
-The visual engine is saved to `$WORKSPACE_DIR/$MODEL_NAME/engine/visual/`.
-
-### 3.3 Create an Input File
-
-Save the following as `$WORKSPACE_DIR/input_vlm.json`. Use an absolute path for the image:
-
-```bash
-cat > $WORKSPACE_DIR/input_vlm.json << 'EOF'
-{
-    "batch_size": 1,
-    "temperature": 1.0,
-    "top_p": 1.0,
-    "top_k": 50,
-    "max_generate_length": 128,
-    "requests": [
-        {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image",
-                            "image": "IMAGE_PATH_PLACEHOLDER"
-                        },
-                        {
-                            "type": "text",
-                            "text": "Describe what you see in this image."
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-EOF
-```
-
-Then replace the image path placeholder with a real image (the repo ships sample images):
-
-```bash
-sed -i "s|IMAGE_PATH_PLACEHOLDER|$(pwd)/examples/multimodal/pics/red_panda.jpeg|" \
-    $WORKSPACE_DIR/input_vlm.json
-```
-
-<div class="admonition tip">
-<p class="admonition-title">💡 Sample images</p>
-<p>The repo ships test images at <code>~/TensorRT-Edge-LLM/examples/multimodal/pics/</code> including <code>red_panda.jpeg</code>, <code>giant_panda.jpeg</code>, <code>woman_and_dog.jpeg</code>, and <code>database_er.jpeg</code>.</p>
-</div>
-
-### 3.4 Run Inference
-
-```bash
-./build/examples/llm/llm_inference \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine/llm \
-    --multimodalEngineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --inputFile $WORKSPACE_DIR/input_vlm.json \
-    --outputFile $WORKSPACE_DIR/output_vlm.json \
-    --dumpOutput
-```
-
-### 3.5 Verify Output
-
-<details class="nv-details">
-<summary>Example command and VLM output</summary>
-<div class="nv-details-content">
-
-```bash
-cat $WORKSPACE_DIR/output_vlm.json
-```
-
-You should see a JSON response with the model's description of the image. Example output:
-
-> *"A red panda rests its head on a wooden surface, its fur a rich reddish-brown with white accents on its ears and face, while its dark eyes and black nose stand out against the soft, fluffy texture of its coat."*
-
-</div>
-</details>
-
-## Step 4: Qwen3-4B-Instruct on Jetson Orin Nano 8 GB (INT4 AWQ)
-
-<div style="border-left: 4px solid #d97706; background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%); padding: 16px 20px; border-radius: 0 8px 8px 0; margin-bottom: 1.5rem;">
-<p style="margin: 0; font-size: 1.05rem; font-weight: 600; color: #d97706;">🟠 Jetson Orin Nano 8 GB: 4B LLM with INT4 AWQ quantization</p>
-<p style="margin: 0.5rem 0 0 0; color: #374151; font-size: 0.9rem;">INT4 AWQ reduces Qwen3-4B-Instruct to <strong>~2 GB of weights</strong>, leaving ample room for the KV cache and OS within Orin Nano's 8 GB unified memory. This section runs entirely on <strong>Jetson Orin Nano</strong>. Ensure you completed <a href="#step-2-build-the-c-runtime-on-your-jetson">Step 2</a> on your Orin Nano first.</p>
-</div>
-
-### 4.1 Build the Engine
-
-The memory-optimized parameters below are tuned for Orin Nano 8 GB. If you hit **CUDA out of memory** during the build, reduce the limits further (e.g. `--maxInputLen 256 --maxKVCacheCapacity 512`) and free system memory first:
-
-```bash
-sudo sysctl -w vm.drop_caches=3
-```
-
-```bash
-export MODEL_NAME=Qwen3-4B-Instruct
-
-./build/examples/llm/llm_build \
-    --onnxDir $WORKSPACE_DIR/$MODEL_NAME/onnx \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --maxBatchSize 1 \
-    --maxInputLen 512 \
-    --maxKVCacheCapacity 1024
-```
-
-### 4.2 Create an Input File
-
-```bash
-cat > $WORKSPACE_DIR/input_qwen.json << 'EOF'
-{
-    "batch_size": 1,
-    "temperature": 1.0,
-    "top_p": 1.0,
-    "top_k": 50,
-    "max_generate_length": 512,
-    "requests": [
-        {
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "What are the benefits of running AI models on edge devices like NVIDIA Jetson?"
-                }
-            ]
-        }
-    ]
-}
-EOF
-```
-
-### 4.3 Run Inference
-
-```bash
-./build/examples/llm/llm_inference \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --inputFile $WORKSPACE_DIR/input_qwen.json \
-    --outputFile $WORKSPACE_DIR/output_qwen.json \
-    --dumpOutput
-```
-
-### 4.4 Verify Output
-
-<details class="nv-details">
-<summary>Example command and Qwen3 output (Orin Nano INT4)</summary>
-<div class="nv-details-content">
-
-```bash
-cat $WORKSPACE_DIR/output_qwen.json
-```
-
-Example output from Qwen3-4B-Instruct INT4 on Orin Nano 8 GB:
-
-> *Running AI models on edge devices like NVIDIA Jetson offers several key benefits, making them ideal for real-time, decentralized, and privacy-sensitive applications. The main advantages include:*
->
-> *1. **Low Latency and Real-Time Processing**: Edge devices like NVIDIA Jetson process data locally, eliminating the need to send data to the cloud. This results in near-instant inference, which is critical for time-sensitive applications such as autonomous vehicles, industrial automation, and robotics.*
->
-> *2. **Improved Privacy and Data Security**: Sensitive data (e.g., video, audio, or images) is processed on the device itself, reducing the risk of data exposure, breaches, or unauthorized access.*
->
-> *3. **Reduced Bandwidth Usage**: Since raw data doesn't need to be transmitted to a central server, bandwidth consumption is significantly reduced. This is cost-effective and beneficial in remote or low-connectivity areas.*
->
-> *4. **Reliability and Resilience**: Edge AI enables continuous operation even during network outages or connectivity issues. Devices can function autonomously, ensuring uninterrupted service in critical applications like smart cities or remote monitoring.*
->
-> *5. **Compliance with Regulatory Requirements**: Processing data locally helps organizations meet data sovereignty and privacy regulations.*
-
-</div>
-</details>
-
-## Trying Other Models
-
-The workflow in Steps 1–4 generalises to any model in the [Supported Models](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/docs/source/user_guide/getting_started/supported-models.md) list. Swap the `--model_dir` argument in the quantize and export commands, then rebuild the TensorRT engine on your Jetson. A few worked examples:
-
-### InternVL3 / InternVL3.5
-
-InternVL3 is an open-source VLM family ranging from 1B to 14B. The 1B and 2B models fit Orin Nano with INT4 AWQ; larger variants target AGX Orin or Thor.
-
-```bash
-# Option A: quantize from the original checkpoint
-tensorrt-edgellm-quantize llm \
-    --model_dir OpenGVLab/InternVL3-2B-hf \
-    --output_dir InternVL3-2B/quantized \
-    --quantization int4_awq
-
-tensorrt-edgellm-export \
-    InternVL3-2B/quantized \
-    InternVL3-2B/onnx \
-    --externalize-weights int4_ffn
-
-# Option B: use a pre-quantized AWQ checkpoint (skip the quantize step)
-tensorrt-edgellm-export \
-    OpenGVLab/InternVL3-2B-AWQ \
-    InternVL3-2B/onnx \
-    --externalize-weights int4_ffn
-```
-
-Build and run on your Jetson exactly as in Steps 3–4 (use `llm_build` for the LLM engine and `visual_build` for the vision encoder, then `llm_inference` with `--multimodalEngineDir`).
-
-### Qwen3.5 / Qwen3.6 Text
-
-Qwen3.5 and Qwen3.6 dense text models follow the same workflow as Qwen3. Available sizes are 0.8B, 2B, 4B, 9B, and 27B — there are no separate Instruct checkpoints; the base checkpoints support instruction following directly.
-
-```bash
-# Qwen3.5-4B with INT4 AWQ — fits Orin Nano 8 GB
-tensorrt-edgellm-quantize llm \
-    --model_dir Qwen/Qwen3.5-4B \
-    --output_dir Qwen3.5-4B/quantized \
-    --quantization int4_awq
-
-tensorrt-edgellm-export \
-    Qwen3.5-4B/quantized \
-    Qwen3.5-4B/onnx \
-    --externalize-weights int4_ffn
-```
-
-### Nemotron-Nano 4B
-
-NVIDIA Nemotron-Nano uses a hybrid Mamba2+Attention architecture. Pre-quantized checkpoints export directly — no separate quantize step needed.
-
-```bash
-# NVFP4 pre-quantized — Thor only (SM110+)
-tensorrt-edgellm-export \
-    nvidia/NVIDIA-Nemotron-3-Nano-4B-NVFP4 \
-    Nemotron-Nano-4B/onnx
-
-# BF16 original — Orin (export directly, runs as FP16 on device)
-tensorrt-edgellm-export \
-    nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16 \
-    Nemotron-Nano-4B/onnx
-```
-
-<div class="admonition tip">
-<p class="admonition-title">Memory guidance for Orin Nano INT4 builds</p>
-<p>Pass <code>--externalize-weights int4_ffn</code> to <code>tensorrt-edgellm-export</code> for dense INT4 checkpoints to reduce peak engine-build memory. For MoE checkpoints add <code>int4_moe</code> to that flag.</p>
-</div>
-
-## Performance and Benchmarking
-
-TensorRT Edge-LLM publishes released performance results in its [Performance Benchmarks](https://nvidia.github.io/TensorRT-Edge-LLM/latest/user_guide/performance/performance-benchmarks.html) section. The benchmark page covers Jetson AGX Thor results across LLM and VLM workloads, including prefill latency, prefill throughput, generation throughput, GPU memory usage, visual encoder throughput, and speculative decoding speedups.
-
-For the engines built in this tutorial, use `llm_inference` when you want end-to-end application timing with real JSON requests, and use `llm_bench` when you want synthetic prefill or decode measurements without preparing request files.
-
-Benchmark a built LLM engine:
-
-```bash
-cd ~/TensorRT-Edge-LLM
-
-./build/examples/llm/llm_bench \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --mode prefill \
-    --inputLen 128 \
-    --batchSize 1
-```
-
-Collect a layer-level profile:
-
-```bash
-./build/examples/llm/llm_bench \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --mode generation \
-    --inputLen 128 \
-    --outputLen 128 \
-    --batchSize 1 \
-    --profile
-```
-
-For end-to-end application measurements, run `llm_inference` with `--dumpProfile` and, optionally, `--profileOutputFile`:
-
-```bash
-./build/examples/llm/llm_inference \
-    --engineDir $WORKSPACE_DIR/$MODEL_NAME/engine \
-    --inputFile $WORKSPACE_DIR/input_qwen.json \
-    --outputFile $WORKSPACE_DIR/output_qwen.json \
-    --dumpProfile \
-    --profileOutputFile $WORKSPACE_DIR/profile_qwen.json
-```
-
-<div class="admonition note">
-<p class="admonition-title">Benchmark context</p>
-<p>The released Edge-LLM benchmark tables use default TensorRT Edge-LLM inference settings on Jetson AGX Thor. Local results can vary with Jetson model, power mode, memory pressure, thermal state, CUDA/TensorRT version, batch size, prompt length, and generation length.</p>
-</div>
-
-## Integrating Edge-LLM in Your C++ Application
-
-The `llm_inference` binary used above is a reference application. For production use (robotics, camera apps, industrial inspection, kiosks), you integrate Edge-LLM directly via the C++ API. The API surface is three calls: create a runtime, capture CUDA graphs, then call `handleRequest()` per query. See the [C++ runtime headers](https://github.com/NVIDIA/TensorRT-Edge-LLM/tree/main/cpp/runtime) and [example application](https://github.com/NVIDIA/TensorRT-Edge-LLM/tree/main/examples/llm) on GitHub.
+These flags do not quantize the base or draft. If the pair does not fit the
+target device in its published precision, select a smaller published pair.
 
 ## Troubleshooting
 
-<details class="nv-details">
-<summary>Why not use plain <code>pip install</code> on Jetson (Thor container)?</summary>
-<div class="nv-details-content">
-
-The generic PyPI torch wheel does not work on Jetson. It can raise <code>AttributeError: module 'torch._C' has no attribute '_dlpack_exchange_api'</code>. The NVIDIA PyTorch container includes a Jetson-built <code>torch</code>. The setup in this tutorial uses <code>--system-site-packages</code> on the venv so that build is visible, <code>pip3 install --no-deps .</code> so pip does not overwrite <code>torch</code>, and a filtered <code>requirements.txt</code> (with <code>torch</code> lines removed) to pull in the remaining packages (transformers, datasets, onnx, etc.) without replacing <code>torch</code> or <code>torchvision</code>.
-
-</div>
-</details>
-
-<details class="nv-details">
-<summary>Export fails with out-of-memory on x86 host</summary>
-<div class="nv-details-content">
-
-FP8 ONNX export can require up to 6x the model size in GPU VRAM and 20x in CPU RAM for 8B models. Use INT4 AWQ quantization instead, which is less memory-intensive, or add `--shm-size=16g` to the `docker run` command.
-
-</div>
-</details>
-
-<details class="nv-details">
-<summary>Slow build or <code>make</code> crashes on Orin Nano</summary>
-<div class="nv-details-content">
-
-Orin Nano has limited RAM. Reduce parallelism: `make -j4` instead of `make -j$(nproc)`, or run `make` without the `-j` flag for a sequential build.
-
-</div>
-</details>
+- **Unsupported quantization:** use the exact Edge-LLM checkpoint shown on the
+  model card. Do not pass its vLLM `compressed-tensors` or llama.cpp GGUF file.
+- **Checkpoint access denied:** accept the Hugging Face license and pass
+  `HF_TOKEN` to Docker.
+- **Engine build runs out of memory:** lower batch, input, KV-cache, or image
+  token profile limits. If weights already exceed the table's target, choose a
+  smaller published checkpoint.
+- **Engine fails on another Jetson:** TensorRT engines are device-specific.
+  Reuse downloaded checkpoints and ONNX, but build the engine on its target.
+- **Need reproducibility details:** inspect `manifest.json` and `commands.sh`
+  in the run directory before changing profile options.
 
 ## References
 
-- [TensorRT Edge-LLM GitHub](https://github.com/NVIDIA/TensorRT-Edge-LLM)
-- [Supported Models on TensorRT Edge-LLM ](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/docs/source/user_guide/getting_started/supported-models.md)
-- [Official TensorRT Edge-LLM Documentation](https://nvidia.github.io/TensorRT-Edge-LLM/latest/)
-- [TensorRT Edge-LLM Performance Benchmarks](https://nvidia.github.io/TensorRT-Edge-LLM/latest/user_guide/performance/performance-benchmarks.html)
-- [Jetson Linux R39.2 Release Notes](https://docs.nvidia.com/jetson/archives/r39.2/ReleaseNotes/Jetson_Linux_Release_Notes_r39.2.pdf)
-- [CUDA for Tegra Application Note](https://docs.nvidia.com/cuda/pdf/CUDA-For-Tegra-AppNote.pdf)
-- [Hackster.io: Getting Started with TensorRT Edge-LLM on Jetson Thor](https://www.hackster.io/shahizat/getting-started-with-nvidia-tensorrt-edge-llm-on-jetson-thor-14735e)
+- [TensorRT Edge-LLM 0.10.0 supported models](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/release/0.10.0/docs/source/user_guide/getting_started/supported-models.md)
+- [TensorRT Edge-LLM 0.10.0 experimental ONNX-less builder](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/release/0.10.0/docs/source/user_guide/getting_started/direct-engine-builder.md)
+- [TensorRT Edge-LLM documentation](https://nvidia.github.io/TensorRT-Edge-LLM/latest/)
+- [TensorRT Edge-LLM performance benchmarks](https://nvidia.github.io/TensorRT-Edge-LLM/latest/user_guide/performance/performance-benchmarks.html)

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -40,7 +40,7 @@
   "notes": [
     "Unless otherwise specified, all models utilize W4A16 quantization for Orin and NVFP4 for Thor.",
     "NVFP4 and MXFP4 require Blackwell FP4 tensor cores and are not available on Orin (Ampere).",
-    "Edge-LLM benchmark values are generation throughput from the official TensorRT Edge-LLM performance benchmarks on Jetson AGX Thor Developer Kit.",
+    "TensorRT Edge-LLM benchmark values are generation throughput from the official TensorRT Edge-LLM performance benchmarks on Jetson AGX Thor Developer Kit.",
     "Cosmos3 Edge (Reasoner) (BF16): streaming chat harness, ISL 1705 / OSL 128, per-request prompt-cache salting, median of 3 - not the aiperf ISL-2048 protocol used for other rows."
   ],
   "models": [
@@ -218,7 +218,7 @@
       "isl": 2048,
       "osl": 128,
       "engines": {
-        "Edge-LLM": {
+        "TensorRT Edge-LLM": {
           "NVFP4": {
             "concurrency1": {
               "t5000": 64.7,
@@ -352,7 +352,7 @@
             }
           }
         },
-        "Edge-LLM": {
+        "TensorRT Edge-LLM": {
           "NVFP4": {
             "concurrency1": {
               "t5000": 31.3,
@@ -575,7 +575,7 @@
             }
           }
         },
-        "Edge-LLM": {
+        "TensorRT Edge-LLM": {
           "NVFP4": {
             "concurrency1": {
               "t5000": 90.2,
@@ -719,7 +719,7 @@
             }
           }
         },
-        "Edge-LLM": {
+        "TensorRT Edge-LLM": {
           "INT4 GPTQ": {
             "concurrency1": {
               "t5000": 72.6,

--- a/src/lib/catalogModelFilters.ts
+++ b/src/lib/catalogModelFilters.ts
@@ -22,7 +22,7 @@ export const CATALOG_ENGINE_FILTERS: readonly { uiId: string; label: string }[] 
 	{ uiId: 'vllm', label: 'vLLM' },
 	{ uiId: 'ollama', label: 'Ollama' },
 	{ uiId: 'llamacpp', label: 'llama.cpp' },
-	{ uiId: 'edgemllm', label: 'Edge-LLM' },
+	{ uiId: 'edgellm', label: 'TensorRT Edge-LLM' },
 ];
 
 function oneShotModuleIdsWithContent(o: OneShotForRunModal): string[] {
@@ -57,7 +57,7 @@ function inferEngineUiIdsFromOneShot(o: OneShotForRunModal | undefined): string[
 		{ id: 'ollama', re: /\boolama\b/i },
 		{ id: 'vllm', re: /\bvllm\b/i },
 		{ id: 'llamacpp', re: /\b(llama\.cpp|llamacpp)\b/i },
-		{ id: 'edgemllm', re: /\b(edge[\s-]?llm|edgemllm|tensorrt[\s-]?llm|trt_llm)\b/i },
+		{ id: 'edgellm', re: /\b(edge[\s-]?llm|edgemllm|tensorrt[\s-]?llm|trt_llm)\b/i },
 	];
 	for (const { id, re } of checks) {
 		if (re.test(text)) found.add(id);

--- a/src/lib/engines.ts
+++ b/src/lib/engines.ts
@@ -42,13 +42,13 @@ export const INFERENCE_ENGINES: Record<string, InferenceEngine> = {
 			return `sglang serve ${checkpoint}`;
 		}
 	},
-	edgemllm: {
-		id: 'edgemllm',
-		label: 'EdgeLLM',
+	edgellm: {
+		id: 'edgellm',
+		label: 'TensorRT Edge-LLM',
 		supports: ['Text', 'Multimodal'],
 		buildCommand: ({ modelId }) => {
 			const cliModel = sanitizeModelForCli(modelId);
-			return `echo "Configure EdgeLLM for ${cliModel} (see model YAML run commands)"`;
+			return `echo "Configure TensorRT Edge-LLM for ${cliModel} (see model YAML run commands)"`;
 		}
 	},
 	llamacpp: {

--- a/src/lib/inferenceCommands.ts
+++ b/src/lib/inferenceCommands.ts
@@ -165,8 +165,15 @@ export function moduleById(id: string): JetsonModuleSpec | undefined {
 	return JETSON_MATRIX_MODULES.find((m) => m.id === id);
 }
 
-function normalizedEngineKey(s: string): string {
-	return s.toLowerCase().replace(/[.\-_]/g, '');
+const ENGINE_KEY_ALIASES: Readonly<Record<string, string>> = {
+	edgemllm: 'edgellm',
+	tensorrtedgellm: 'edgellm',
+	vllmomni: 'vllm',
+};
+
+export function normalizeEngineKey(s: string): string {
+	const key = s.trim().toLowerCase().replace(/[.\-_\s]/g, '');
+	return ENGINE_KEY_ALIASES[key] ?? key;
 }
 
 /** Install + run for one platform (same strings the model page and modal must show). */
@@ -314,11 +321,10 @@ export function matchSupportedEngine(
 	supportedEngines: SupportedEngineEntry[],
 	engineId: string
 ): SupportedEngineEntry | undefined {
-	const normId = normalizedEngineKey(engineId);
+	const normId = normalizeEngineKey(engineId);
 	return supportedEngines.find((e) => {
 		if (!e.engine) return false;
-		const n = normalizedEngineKey(e.engine);
-		return n === normId || e.engine.toLowerCase() === engineId.toLowerCase();
+		return normalizeEngineKey(e.engine) === normId;
 	});
 }
 
@@ -329,16 +335,7 @@ export function filterEnginesForModel(
 ): InferenceEngine[] {
 	let engines = enginesForCategory(category);
 	if (supportedEngines?.length) {
-		const supportedIds = supportedEngines.map((e) => e.engine.toLowerCase());
-		engines = engines.filter(
-			(e) => supportedIds.includes(e.id) || supportedIds.includes(e.label.toLowerCase())
-		);
-		if (engines.length === 0) {
-			const allEngines = enginesForCategory(category);
-			engines = allEngines.filter((e) =>
-				supportedIds.some((id) => id.includes(e.id) || e.id.includes(id))
-			);
-		}
+		engines = engines.filter((e) => matchSupportedEngine(supportedEngines, e.id));
 	}
 	return engines;
 }

--- a/src/lib/modelFrontmatterAdapter.ts
+++ b/src/lib/modelFrontmatterAdapter.ts
@@ -1,6 +1,4 @@
-import {
-	type SupportedEngineEntry,
-} from './inferenceCommands';
+import { normalizeEngineKey, type SupportedEngineEntry } from './inferenceCommands';
 
 /** Shape needed to resolve engines (matches model collection data; avoid importing content/config from lib). */
 export interface ModelEnginesSource {
@@ -59,13 +57,13 @@ const ENGINE_ORDER: Record<string, number> = {
 };
 
 function engineSortKey(engine: string): number {
-	const key = engine.toLowerCase().replace(/[.\-_ ]/g, '');
+	const key = normalizeEngineKey(engine);
 	return ENGINE_ORDER[key] ?? 99;
 }
 
 /**
  * Order engines for the serve matrix / Run modal.
- * Fixed order: vLLM > SGLang > llama.cpp > Ollama > Edge-LLM > everything else (alphabetical).
+ * Fixed order: vLLM > SGLang > llama.cpp > Ollama > TensorRT Edge-LLM > everything else (alphabetical).
  */
 export function sortEnginesForUi(engines: SupportedEngineEntry[]): SupportedEngineEntry[] {
 	if (engines.length <= 1) return [...engines];


### PR DESCRIPTION
## Summary

- Upgrade the TensorRT Edge-LLM integration to the 0.10.0 Orin and Thor container images.
- Add a one-command workflow that resolves a public Hugging Face checkpoint, builds every detected component, runs the model-specific C++ inference contract, records benchmarks and commands, and reuses matching artifacts.
- Default offline inference to the experimental ONNX-less `tensorrt-edgellm-build` frontend. Keep `--builder onnx` for the 0.10.0 HTTP server and Nemotron 3.5 streaming ASR.
- Add model-specific text, image/video, audio, speech, diffusion, and action contracts for the supported 0.10.0 families.
- Add Qwen3.8 27B on Thor with a public ModelOpt NVFP4 checkpoint, multimodal serving, and optional native MTP.
- Make all catalog server commands select `--builder onnx` explicitly.
- Keep MTP, EAGLE3, DFlash, and DSpark opt-in. MTP, EAGLE3, and DFlash extend compatible text models without changing their base multimodal contract.

## Support And Server Audit

- The weightless registry contains 26 model families and 68 root/component `model_type` aliases.
- The release documentation names 186 unique Hugging Face IDs. Anonymous `config.json` access succeeded for 176; gated IDs are identified separately.
- All 49 deployment checkpoints recommended by the fixed August 13 tutorial audit exposed metadata and a weight artifact anonymously.
- A 49/49 helper contract sweep passed:
  - 42 checkpoints reached the model-appropriate HTTP launcher.
  - DiffusionGemma, Cosmos3 policy, and Nemotron 3.5 RNN-T ASR remained on their model-specific offline runtimes.
  - Four Gemma4 NVFP4 checkpoints were rejected before export because Edge-LLM 0.10.0 shared-KV prefill cannot read their FP8 donor cache.
- Qwen3.8 was added after that fixed audit. Its public ModelOpt NVFP4 checkpoint independently passed plain and native-MTP command planning, export, every component engine build, and runtime validation.
- The official `Qwen/Qwen3.8-27B-FP8` fine-grained Transformers FP8 format is rejected before export; the documented command therefore uses `Inferact/Qwen3.8-27B-NVFP4`.
- A separate replay of every previously published Edge-LLM model-card command passed 42/42 on the final rebased tree; the new Qwen3.8 command also passed independently.
- The support matrix now distinguishes source registration, HTTP contract, and completed hardware evidence.

## HTTP Contracts

- Text models: OpenAI-compatible chat completions.
- VLMs: text plus image/video chat, with an explicit local-media allowlist.
- Qwen3-ASR: multimodal chat and `/v1/audio/transcriptions`.
- Qwen3-TTS CustomVoice: `/v1/audio/speech`.
- Gemma4: text, image, and checkpoint-dependent audio chat when the checkpoint uses an FP16 KV cache.
- MTP, EAGLE3, and DFlash: explicit text-only speculative server extensions in 0.10.0.

## Hardware Validation

- **Orin Nano 8 GB:** Qwen3.5 2B AWQ weightless LLM and vision engines; coherent image response and benchmark collection.
- **Orin NX 16 GB:** Qwen2.5 text chat preserved context; Qwen3.5 visual chat correctly described a real beach image; Qwen3 1.7B plus EAGLE3 reported speculative decoding and returned `17 x 6 = 102`.
- **Jetson AGX Orin 64 GB:** Qwen3.5 9B W4A16 GPTQ weightless LLM and vision engines produced a coherent image response and benchmark results.
- **Jetson AGX Thor 128 GB:** Qwen3-ASR returned the exact LibriSpeech sentence through both audio APIs.
- **Jetson AGX Thor 128 GB:** Qwen3-TTS returned a valid 24 kHz mono WAV; Qwen3-ASR recovered the intended NVIDIA Jetson/Edge AI sentence.
- **Jetson AGX Thor 128 GB:** Gemma4 E2B W4A16 GPTQ built LLM, visual, and audio engines. Text preserved context, image chat identified the woman/dog/beach scene, and audio chat produced the exact transcript.
- **Jetson AGX Thor 128 GB:** Qwen3.8 27B ModelOpt NVFP4 built LLM and visual engines. Text, JPEG, and MP4 requests returned coherent answers; the native MTP server reported speculative decoding and returned `23 x 9 = 207`.
- **Jetson AGX Thor 128 GB:** native Qwen3.5 MTP and the public Qwen3.5 DFlash pair both reported speculative decoding and returned the correct arithmetic answers.
- **Jetson AGX Thor 128 GB:** Cosmos3 DROID policy produced a finite `1x16x10` action chunk through its model-specific runtime.
- Semantic assertions over the earlier saved server responses passed 19/19. Qwen3.8 added passing text, image, video, and native-MTP checks.

## Checks

- Rebased onto current `main`; the branch is one commit ahead.
- `bash -n`, CLI help, `git diff --check`, server-contract guards, and credential scans pass.
- Final previously published model-card command replay: 42/42 passed; the new Qwen3.8 plain and MTP plans passed separately.
- Production site build: `npm run build` passed.
- Temporary engines, checkpoints, media, containers, and dedicated test volumes were removed from the devices after evidence collection.
