### PR TITLE
Add validated TensorRT Edge-LLM path for Nemotron 3.5 Lightning

### DIFF
--- a/public/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh
+++ b/public/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Build and serve NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 with TensorRT Edge-LLM 0.10.0.
+# This helper deliberately supports this one checkpoint only; it is the staged validation path
+# for the Jetson AI Lab model card.
+set -euo pipefail
+
+readonly MODEL_ID='nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4'
+readonly EDGE_LLM_VERSION='0.10.0'
+
+stage='serve'
+workspace='/data/edgellm/nemotron3-5-lightning'
+port='8000'
+max_batch_size='1'
+max_input_len='2048'
+max_kv_cache_capacity='2200'
+dry_run='false'
+
+usage() {
+	printf '%s\n' \
+		'Usage: run-nemotron35-lightning [options]' \
+		'' \
+		'Build and serve NVIDIA Nemotron 3.5 Lightning NVFP4 with TensorRT Edge-LLM 0.10.0.' \
+		'' \
+		'Options:' \
+		'  --stage export|build|serve  Run one stage (default: serve; includes export and build)' \
+		'  --workspace PATH            Persistent workspace (default: /data/edgellm/nemotron3-5-lightning)' \
+		'  --port PORT                 OpenAI-compatible server port (default: 8000)' \
+		'  --max-batch-size N          Engine maximum batch size (default: 1)' \
+		'  --max-input-len N           Engine maximum input tokens (default: 2048)' \
+		'  --max-kv-cache-capacity N   Engine KV-cache capacity (default: 2200)' \
+		'  --dry-run                   Print the commands without downloading, building, or serving' \
+		'  -h, --help                  Show this help'
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while (($#)); do
+	case "$1" in
+		--stage) stage="${2:-}"; shift 2 ;;
+		--workspace) workspace="${2:-}"; shift 2 ;;
+		--port) port="${2:-}"; shift 2 ;;
+		--max-batch-size) max_batch_size="${2:-}"; shift 2 ;;
+		--max-input-len) max_input_len="${2:-}"; shift 2 ;;
+		--max-kv-cache-capacity) max_kv_cache_capacity="${2:-}"; shift 2 ;;
+		--dry-run) dry_run='true'; shift ;;
+		-h|--help) usage; exit 0 ;;
+		*) die "unknown option: $1" ;;
+	esac
+done
+
+[[ "$stage" =~ ^(export|build|serve)$ ]] || die '--stage must be export, build, or serve'
+[[ "$port" =~ ^[1-9][0-9]{0,4}$ ]] && ((port <= 65535)) || die '--port must be between 1 and 65535'
+for value in "$max_batch_size" "$max_input_len" "$max_kv_cache_capacity"; do
+	[[ "$value" =~ ^[1-9][0-9]*$ ]] || die 'engine limits must be positive integers'
+done
+
+edgellm_home="${EDGELLM_HOME:-/opt/TensorRT-Edge-LLM}"
+[[ -f "$edgellm_home/CMakeLists.txt" ]] || die "TensorRT Edge-LLM source was not found at $edgellm_home"
+if [[ -f "$edgellm_home/tensorrt_edgellm/_version.py" ]]; then
+	installed_version="$(awk -F '"' '/^__version__[[:space:]]*=/ { print $2; exit }' "$edgellm_home/tensorrt_edgellm/_version.py")"
+	[[ -z "$installed_version" || "$installed_version" == "$EDGE_LLM_VERSION" ]] || die "expected Edge-LLM $EDGE_LLM_VERSION, found $installed_version"
+fi
+
+model_dir="$workspace/model"
+export_dir="$workspace/onnx"
+engine_dir="$workspace/engines/b${max_batch_size}-i${max_input_len}-kv${max_kv_cache_capacity}"
+llm_build="$edgellm_home/build/examples/llm/llm_build"
+if command -v tensorrt-edgellm-export >/dev/null; then
+	export_tool=(tensorrt-edgellm-export)
+else
+	export_tool=(python3 -m tensorrt_edgellm.scripts.export)
+fi
+
+run() {
+	printf '+ '
+	printf '%q ' "$@"
+	printf '\n'
+	[[ "$dry_run" == 'true' ]] || "$@"
+}
+
+download_model() {
+	if [[ -f "$model_dir/config.json" ]]; then
+		echo "Reusing checkpoint: $model_dir"
+		return
+	fi
+	run mkdir -p "$model_dir"
+	if [[ "$dry_run" == 'true' ]]; then return; fi
+	python3 - "$model_dir" "$MODEL_ID" <<'PY'
+from pathlib import Path
+from huggingface_hub import snapshot_download
+
+snapshot_download(
+    repo_id=__import__('sys').argv[2],
+    local_dir=Path(__import__('sys').argv[1]),
+)
+PY
+}
+
+copy_external_weights() {
+	[[ "$dry_run" == 'true' ]] && return
+	python3 - "$export_dir/llm" "$engine_dir" <<'PY'
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+source, destination = map(Path, sys.argv[1:])
+for entry in json.loads((source / 'config.json').read_text()).get('external_weight_files', []):
+    name = entry.get('file')
+    if not isinstance(name, str):
+        raise SystemExit(f'invalid external-weight entry: {entry!r}')
+    src = (source / name).resolve()
+    dst = destination / name
+    if source.resolve() not in src.parents or not src.is_file():
+        raise SystemExit(f'missing external weight: {name}')
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() and src.samefile(dst):
+        continue
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+PY
+}
+
+if [[ "$stage" == 'export' || "$stage" == 'serve' ]]; then
+	download_model
+	run mkdir -p "$export_dir"
+	if [[ "$dry_run" == 'true' || ! -f "$export_dir/llm/model.onnx" ]]; then
+		run "${export_tool[@]}" "$model_dir" "$export_dir" \
+			--max-kv-cache-capacity "$max_kv_cache_capacity" \
+			--externalize-weights nvfp4_moe
+	else
+		echo "Reusing ONNX export: $export_dir"
+	fi
+fi
+
+if [[ "$stage" == 'build' || "$stage" == 'serve' ]]; then
+	[[ "$dry_run" == 'true' || -f "$export_dir/llm/model.onnx" ]] || die "missing ONNX export: $export_dir/llm/model.onnx (run --stage export first)"
+	run mkdir -p "$engine_dir"
+	copy_external_weights
+	if [[ "$dry_run" == 'true' || ! -x "$llm_build" ]]; then
+		run cmake --build "$edgellm_home/build" --target llm_build --parallel "$(nproc)"
+	fi
+	if [[ "$dry_run" == 'true' || ! -f "$engine_dir/llm.engine" ]]; then
+		run "$llm_build" --onnxDir "$export_dir/llm" --engineDir "$engine_dir" \
+			--maxBatchSize "$max_batch_size" \
+			--maxInputLen "$max_input_len" \
+			--maxKVCacheCapacity "$max_kv_cache_capacity"
+	else
+		echo "Reusing engine: $engine_dir/llm.engine"
+	fi
+fi
+
+if [[ "$stage" == 'serve' ]]; then
+	[[ "$dry_run" == 'true' || -f "$engine_dir/llm.engine" ]] || die "missing engine: $engine_dir/llm.engine"
+	run python3 -c "from experimental.server import LLM; LLM(engine_dir='$engine_dir').serve(host='0.0.0.0', port=$port)"
+fi

--- a/src/components/RunCommand.astro
+++ b/src/components/RunCommand.astro
@@ -1,6 +1,6 @@
 ---
 import type { InferenceCategory } from '../lib/engines';
-import { enginesForCategory, defaultEngineForCategory } from '../lib/engines';
+import { defaultEngineForCategory } from '../lib/engines';
 import { sortEnginesForUi } from '../lib/modelFrontmatterAdapter';
 import {
 	applyMatrixModuleDisabledFlags,
@@ -8,7 +8,9 @@ import {
 	buildModuleCommandMatrix,
 	engineHasPlatformContent,
 	engineSupportsModule,
+	filterEnginesForModel,
 	matchSupportedEngine,
+	normalizeEngineKey,
 	type SupportedEngineEntry,
 	visibleModulesForEngines,
 	moduleIdToPlatformMap,
@@ -64,32 +66,19 @@ const {
 	oneShotInference = null,
 } = Astro.props as Props;
 
-let engines = enginesForCategory(category);
+let engines = filterEnginesForModel(category, supportedEngines);
 
-// Filter engines if supportedEngines is provided
 if (supportedEngines && supportedEngines.length > 0) {
-    const supportedIds = supportedEngines.map(e => e.engine.toLowerCase());
-    // Map markdown engine names (e.g., "Ollama", "vLLM") to engine IDs (e.g., "ollama", "vllm")
-    // Special handling for vLLM if needed, but toLowerCase usually works if IDs are lowercase
-    engines = engines.filter(e => supportedIds.includes(e.id) || supportedIds.includes(e.label.toLowerCase()));
-    
-    // If filtering resulted in empty list (mismatch), fall back to all category engines or handle error
-    if (engines.length === 0) {
-        // Fallback: try to find engines that match loosely
-         const allEngines = enginesForCategory(category);
-         engines = allEngines.filter(e => supportedIds.some(id => id.includes(e.id) || e.id.includes(id)));
-    }
-    const sortedYaml = sortEnginesForUi(supportedEngines as SupportedEngineEntry[]);
-    const rank = new Map<string, number>();
-    sortedYaml.forEach((se, i) => {
-      const k = se.engine.toLowerCase().replace(/[.\-_]/g, '');
-      rank.set(k, i);
-    });
-    engines = [...engines].sort((a, b) => {
-      const ka = a.id.replace(/[.\-_]/g, '');
-      const kb = b.id.replace(/[.\-_]/g, '');
-      return (rank.get(ka) ?? 99) - (rank.get(kb) ?? 99);
-    });
+	const sortedYaml = sortEnginesForUi(supportedEngines as SupportedEngineEntry[]);
+	const rank = new Map<string, number>();
+	sortedYaml.forEach((se, i) => {
+		rank.set(normalizeEngineKey(se.engine), i);
+	});
+	engines = [...engines].sort((a, b) => {
+		const ka = normalizeEngineKey(a.id);
+		const kb = normalizeEngineKey(b.id);
+		return (rank.get(ka) ?? 99) - (rank.get(kb) ?? 99);
+	});
 }
 
 const defaultEngine = defaultEngineForCategory(category);

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -129,10 +129,11 @@ serving:
         - thor_t4000
       install_command: |-
         mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        # This production URL is published when this change is merged and deployed.
         curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh -o "$HOME/run-nemotron35-lightning"
         chmod +x "$HOME/run-nemotron35-lightning"
       serve_command_thor: |-
-        sudo docker run -it --rm --pull always --runtime=nvidia --network host -v "$HOME/run-nemotron35-lightning:/usr/local/bin/run-nemotron35-lightning:ro" -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" -v "$HOME/.cache/huggingface:/data/models/huggingface" ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor run-nemotron35-lightning --stage serve
+        sudo docker run -it --rm --pull always --ipc=host --runtime=nvidia --network host -v "$HOME/run-nemotron35-lightning:/usr/local/bin/run-nemotron35-lightning:ro" -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" -v "$HOME/.cache/huggingface:/data/models/huggingface" ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor run-nemotron35-lightning --stage serve
 ---
 
 NVIDIA Nemotron 3.5 Lightning is a fast, open-weight 30B Mixture-of-Experts model that activates only 3B parameters per token. It brings performance close to the much larger Nemotron 3 Super while remaining practical for local coding assistants, research agents, tool-calling workflows, and other always-on applications.
@@ -168,6 +169,12 @@ Output: Text
 Nemotron 3.5 Lightning includes Multi-Token Prediction and is released with dedicated DSpark and DFlash checkpoints. The vLLM commands use DSpark with five speculative tokens, which was the fastest configuration in our testing on both supported Jetson platforms. The `llama.cpp` commands use the DFlash checkpoint.
 
 The vLLM server exposes an OpenAI-compatible API on port `8000` with reasoning parsing, automatic tool selection, and the Qwen3 Coder tool-call parser enabled. The `llama.cpp` server exposes its API on port `8080`.
+
+## TensorRT Edge-LLM on Jetson Thor
+
+The TensorRT Edge-LLM command is an experimental, **Thor-only** NVFP4 path. Its default engine is intentionally conservative: batch size 1, maximum input length 2048 tokens, and KV-cache capacity 2200 tokens. The model's 1M-token capability is not enabled by this engine configuration.
+
+Standard OpenAI-compatible chat completions have been validated on Jetson AGX Thor. OpenAI `tools` requests are not supported by this TensorRT Edge-LLM 0.10.0 sample because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
 
 ## Additional Resources
 

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -176,6 +176,17 @@ The TensorRT Edge-LLM command is an experimental, **Thor-only** NVFP4 path. Its 
 
 Standard OpenAI-compatible chat completions have been validated on Jetson AGX Thor. OpenAI `tools` requests are not supported by this TensorRT Edge-LLM 0.10.0 sample because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
 
+### Pre-merge staging validation
+
+The public helper URL in the install command is published only after this change is merged and deployed to `jetson-ai-lab`. It returns `404` before then by design. For staging validation, obtain the helper from the checked-out staging branch instead of using the production URL:
+
+```bash
+cp public/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh "$HOME/run-nemotron35-lightning"
+chmod +x "$HOME/run-nemotron35-lightning"
+```
+
+Alternatively, a reviewer with access to the private staging repository can download that same file with `gh api` and the `feat/nemotron-3-5-lightning-edgellm` ref. The staging Pages site is access-controlled and is not a reliable unauthenticated `curl` distribution endpoint.
+
 ## Additional Resources
 
 - [Nemotron 3.5 Lightning NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4)

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -122,6 +122,17 @@ serving:
             --top-p 0.95 \
             --host 0.0.0.0 \
             --port 8080
+    - engine: "TensorRT Edge-LLM"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+      install_command: |-
+        mkdir -p "$HOME/tensorrt-edgellm-workspace" "$HOME/.cache/huggingface"
+        curl -fsSL https://www.jetson-ai-lab.com/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh -o "$HOME/run-nemotron35-lightning"
+        chmod +x "$HOME/run-nemotron35-lightning"
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always --runtime=nvidia --network host -v "$HOME/run-nemotron35-lightning:/usr/local/bin/run-nemotron35-lightning:ro" -v "tensorrt-edgellm-0100-build:/opt/TensorRT-Edge-LLM/build" -v "$HOME/tensorrt-edgellm-workspace:/data/edgellm" -v "$HOME/.cache/huggingface:/data/models/huggingface" ghcr.io/nvidia-ai-iot/tensorrt_edge_llm:0.10.0-thor run-nemotron35-lightning --stage serve
 ---
 
 NVIDIA Nemotron 3.5 Lightning is a fast, open-weight 30B Mixture-of-Experts model that activates only 3B parameters per token. It brings performance close to the much larger Nemotron 3 Super while remaining practical for local coding assistants, research agents, tool-calling workflows, and other always-on applications.

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -176,6 +176,8 @@ The TensorRT Edge-LLM command is an experimental, **Thor-only** NVFP4 path. Its 
 
 Standard OpenAI-compatible chat completions have been validated on Jetson AGX Thor. OpenAI `tools` requests are not supported by this TensorRT Edge-LLM 0.10.0 sample because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
 
+The helper serves on port `8000` by default. If that port is already in use, append `--port 8001` after `--stage serve` in the Docker command, then use port `8001` for the OpenAI-compatible API.
+
 ### Pre-merge staging validation
 
 The public helper URL in the install command is published only after this change is merged and deployed to `jetson-ai-lab`. It returns `404` before then by design. For staging validation, obtain the helper from the checked-out staging branch instead of using the production URL:

--- a/src/lib/catalogModelFilters.ts
+++ b/src/lib/catalogModelFilters.ts
@@ -22,7 +22,7 @@ export const CATALOG_ENGINE_FILTERS: readonly { uiId: string; label: string }[] 
 	{ uiId: 'vllm', label: 'vLLM' },
 	{ uiId: 'ollama', label: 'Ollama' },
 	{ uiId: 'llamacpp', label: 'llama.cpp' },
-	{ uiId: 'edgemllm', label: 'Edge-LLM' },
+	{ uiId: 'edgemllm', label: 'TensorRT Edge-LLM' },
 ];
 
 function oneShotModuleIdsWithContent(o: OneShotForRunModal): string[] {

--- a/src/lib/engines.ts
+++ b/src/lib/engines.ts
@@ -44,11 +44,11 @@ export const INFERENCE_ENGINES: Record<string, InferenceEngine> = {
 	},
 	edgemllm: {
 		id: 'edgemllm',
-		label: 'EdgeLLM',
+		label: 'TensorRT Edge-LLM',
 		supports: ['Text', 'Multimodal'],
 		buildCommand: ({ modelId }) => {
 			const cliModel = sanitizeModelForCli(modelId);
-			return `echo "Configure EdgeLLM for ${cliModel} (see model YAML run commands)"`;
+			return `echo "Configure TensorRT Edge-LLM for ${cliModel} (see model YAML run commands)"`;
 		}
 	},
 	llamacpp: {
@@ -135,5 +135,4 @@ export function buildCommandForEngine(engineId: string, args: Parameters<Inferen
 	if (!engine) return '';
 	return engine.buildCommand(args);
 }
-
 

--- a/src/lib/inferenceCommands.ts
+++ b/src/lib/inferenceCommands.ts
@@ -165,8 +165,15 @@ export function moduleById(id: string): JetsonModuleSpec | undefined {
 	return JETSON_MATRIX_MODULES.find((m) => m.id === id);
 }
 
-function normalizedEngineKey(s: string): string {
-	return s.toLowerCase().replace(/[.\-_]/g, '');
+const ENGINE_KEY_ALIASES: Readonly<Record<string, string>> = {
+	edgemllm: 'edgemllm',
+	edgellm: 'edgemllm',
+	tensorrtedgellm: 'edgemllm',
+};
+
+export function normalizeEngineKey(s: string): string {
+	const key = s.trim().toLowerCase().replace(/[.\-_\s]/g, '');
+	return ENGINE_KEY_ALIASES[key] ?? key;
 }
 
 /** Install + run for one platform (same strings the model page and modal must show). */
@@ -314,11 +321,10 @@ export function matchSupportedEngine(
 	supportedEngines: SupportedEngineEntry[],
 	engineId: string
 ): SupportedEngineEntry | undefined {
-	const normId = normalizedEngineKey(engineId);
+	const normId = normalizeEngineKey(engineId);
 	return supportedEngines.find((e) => {
 		if (!e.engine) return false;
-		const n = normalizedEngineKey(e.engine);
-		return n === normId || e.engine.toLowerCase() === engineId.toLowerCase();
+		return normalizeEngineKey(e.engine) === normId;
 	});
 }
 
@@ -329,16 +335,7 @@ export function filterEnginesForModel(
 ): InferenceEngine[] {
 	let engines = enginesForCategory(category);
 	if (supportedEngines?.length) {
-		const supportedIds = supportedEngines.map((e) => e.engine.toLowerCase());
-		engines = engines.filter(
-			(e) => supportedIds.includes(e.id) || supportedIds.includes(e.label.toLowerCase())
-		);
-		if (engines.length === 0) {
-			const allEngines = enginesForCategory(category);
-			engines = allEngines.filter((e) =>
-				supportedIds.some((id) => id.includes(e.id) || e.id.includes(id))
-			);
-		}
+		engines = engines.filter((e) => matchSupportedEngine(supportedEngines, e.id));
 	}
 	return engines;
 }

--- a/src/lib/modelFrontmatterAdapter.ts
+++ b/src/lib/modelFrontmatterAdapter.ts
@@ -1,6 +1,4 @@
-import {
-	type SupportedEngineEntry,
-} from './inferenceCommands';
+import { normalizeEngineKey, type SupportedEngineEntry } from './inferenceCommands';
 
 /** Shape needed to resolve engines (matches model collection data; avoid importing content/config from lib). */
 export interface ModelEnginesSource {
@@ -59,13 +57,13 @@ const ENGINE_ORDER: Record<string, number> = {
 };
 
 function engineSortKey(engine: string): number {
-	const key = engine.toLowerCase().replace(/[.\-_ ]/g, '');
+	const key = normalizeEngineKey(engine);
 	return ENGINE_ORDER[key] ?? 99;
 }
 
 /**
  * Order engines for the serve matrix / Run modal.
- * Fixed order: vLLM > SGLang > llama.cpp > Ollama > Edge-LLM > everything else (alphabetical).
+ * Fixed order: vLLM > SGLang > llama.cpp > Ollama > TensorRT Edge-LLM > everything else (alphabetical).
  */
 export function sortEnginesForUi(engines: SupportedEngineEntry[]): SupportedEngineEntry[] {
 	if (engines.length <= 1) return [...engines];


### PR DESCRIPTION
## Summary

Brings the validated Nemotron 3.5 Lightning TensorRT Edge-LLM subset from staging into the main repository.

- Adds the Thor-only Edge-LLM helper script.
- Adds the Edge-LLM serving option to the Nemotron 3.5 Lightning model page.
- Documents the validated 2,048-token input and 2,200-token KV-cache limits, unsupported tool-calling behavior, cached startup timing, port override, and pre-merge staging distribution path.

## Validation

- `bash -n public/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh`
- `npm run build`
- Jetson AGX Thor (R39.2): checkpoint download, ONNX export, engine build, OpenAI-compatible chat API, input-limit handling, and repeated cached startup.

The cached startup measurement was reproduced at 9.650 s, 9.656 s, and 9.683 s with cached model / ONNX / engine.