### PR TITLE
docs: clarify Lightning Edge-LLM validation scope

### DIFF
--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -176,7 +176,7 @@ The TensorRT Edge-LLM command is an experimental, **Thor-only** NVFP4 path. Its 
 
 The Thor Edge-LLM route has received a **serving smoke pass**, not a full model-behavior validation: the initial model download, export and engine build, server startup, `/v1/models`, and a basic non-streaming chat completion were exercised on Jetson AGX Thor.
 
-Reasoning on/off behavior, streaming, tool calling, and output-format integrity have not been validated for this TensorRT Edge-LLM 0.10.0 sample. Its server does not yet provide a reasoning parser, so reasoning may appear in assistant output. OpenAI `tools` requests are also unsupported because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
+Validation confirms that `enable_thinking=false` works in both regular and streaming chat completions. With `enable_thinking=true`, however, reasoning appears in assistant `content` rather than a separate reasoning field. OpenAI `tools` requests fail in both regular and streaming modes because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
 
 The helper serves on port `8000` by default. If that port is already in use, append `--port 8001` after `--stage serve` in the Docker command, then use port `8001` for the OpenAI-compatible API.
 

--- a/src/content/models/nemotron3-5-lightning.md
+++ b/src/content/models/nemotron3-5-lightning.md
@@ -174,20 +174,11 @@ The vLLM server exposes an OpenAI-compatible API on port `8000` with reasoning p
 
 The TensorRT Edge-LLM command is an experimental, **Thor-only** NVFP4 path. Its default engine is intentionally conservative: batch size 1, maximum input length 2048 tokens, and KV-cache capacity 2200 tokens. The model's 1M-token capability is not enabled by this engine configuration.
 
-Standard OpenAI-compatible chat completions have been validated on Jetson AGX Thor. OpenAI `tools` requests are not supported by this TensorRT Edge-LLM 0.10.0 sample because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
+The Thor Edge-LLM route has received a **serving smoke pass**, not a full model-behavior validation: the initial model download, export and engine build, server startup, `/v1/models`, and a basic non-streaming chat completion were exercised on Jetson AGX Thor.
+
+Reasoning on/off behavior, streaming, tool calling, and output-format integrity have not been validated for this TensorRT Edge-LLM 0.10.0 sample. Its server does not yet provide a reasoning parser, so reasoning may appear in assistant output. OpenAI `tools` requests are also unsupported because the shipped tokenizer configuration cannot apply its tool-aware chat template. Use the vLLM command above for validated tool calling, structured reasoning parsing, long-context tuning, or speculative decoding.
 
 The helper serves on port `8000` by default. If that port is already in use, append `--port 8001` after `--stage serve` in the Docker command, then use port `8001` for the OpenAI-compatible API.
-
-### Pre-merge staging validation
-
-The public helper URL in the install command is published only after this change is merged and deployed to `jetson-ai-lab`. It returns `404` before then by design. For staging validation, obtain the helper from the checked-out staging branch instead of using the production URL:
-
-```bash
-cp public/code-samples/tensorrt_edge_llm/run_nemotron35_lightning.sh "$HOME/run-nemotron35-lightning"
-chmod +x "$HOME/run-nemotron35-lightning"
-```
-
-Alternatively, a reviewer with access to the private staging repository can download that same file with `gh api` and the `feat/nemotron-3-5-lightning-edgellm` ref. The staging Pages site is access-controlled and is not a reliable unauthenticated `curl` distribution endpoint.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

Corrects the Nemotron 3.5 Lightning page so that the TensorRT Edge-LLM integration is described accurately.

The merged Thor path has a **serving smoke pass**. The runtime sweep below shows that it is not ready for structured reasoning or tool-calling use.

## Documentation changes

- Defines the original smoke-test scope: model download, export, TensorRT engine build, server startup, /v1/models, and a basic non-streaming chat completion on Jetson AGX Thor.
- Records the current behavioral results:
  - `enable_thinking=false` works for regular and streaming chat completions.
  - `enable_thinking=true` leaks reasoning into assistant `content` instead of returning a separate reasoning field.
  - OpenAI tools requests fail with HTTP 400 for both regular and streaming calls because the tool-aware chat template cannot be applied.
- Keeps vLLM as the documented route for tool calling, structured reasoning parsing, long-context configuration, and speculative decoding.
- Removes the obsolete pre-merge staging-distribution note.

## Jetson AGX Thor TensorRT Edge-LLM runtime sweep

- Regular and streaming, reasoning disabled: passed.
- Regular and streaming, reasoning enabled: failed the output-format requirement due to reasoning leakage.
- Regular and streaming tool calling: failed (HTTP 400).
- Strict JSON response, 1,531-token prompt, and three sequential requests: passed.
- Reusing the existing engine, three readiness measurements were 15.235 s, 13.442 s, and 9.603 s (mean 12.76 s).

## Checks

- `git diff --check` passed.
- No site build is claimed by this docs-only PR.